### PR TITLE
Export database_exists and fix Quickstart API examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 * Raised minimum Python version from 3.8 to 3.11
 * Raised dependency floors to `pandas>=2.2.0`, `polars[timezone]>=1.0.0`,
   and `pyarrow>=14.0.0` (upper bounds removed)
+* Export `database_exists()` from the top-level `featherstore` package
 
 Enhancements:
 
@@ -18,6 +19,7 @@ Enhancements:
   dtypes (version-gated string metadata constants); sorting uses Arrow
   `sort_indices` so categoricals keep unused categories
 * Snapshot extraction passes `filter='data'` on Python 3.12+
+* Quickstart docs updated for `rename_store(..., to=...)` and `table.exists()`
 
 0.2.1
 -----

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -39,6 +39,7 @@ To create and connect to a new database simply use:
     fs.create_database('/path/to/database_folder')
     fs.connect('/path/to/database_folder')
 
+You can check whether a path is already a database with ``fs.database_exists()``.
 You can later disconnect from the database by using ``fs.disconnect()``
 
 Working with Stores
@@ -58,7 +59,7 @@ and where you can store your tables.
 .. code-block:: python
 
     fs.drop_store('store_2')
-    fs.rename_store('store_1', 'example_store')
+    fs.rename_store('store_1', to='example_store')
     # Connect to store
     store = fs.Store('example_store')
 
@@ -165,9 +166,9 @@ more features for working with tables.
 .. code-block:: python
 
     table = store.select_table('example_table2')
-    table.exists  # False
+    table.exists()  # False
     table.write(df)
-    table.exists
+    table.exists()
 
     >> True
 

--- a/featherstore/__init__.py
+++ b/featherstore/__init__.py
@@ -3,7 +3,8 @@ from featherstore.connection import (
     disconnect,
     create_database,
     current_db,
-    is_connected
+    is_connected,
+    database_exists,
 )
 from featherstore.store import (
     create_store,
@@ -18,5 +19,6 @@ from featherstore import snapshot
 
 __version__ = "0.3.0"
 __all__ = ["connect", "disconnect", "create_database", "current_db",
-           "is_connected", "create_store", "rename_store", "drop_store",
-           "list_stores", "store_exists", "Store", "Table", "snapshot"]
+           "is_connected", "database_exists", "create_store", "rename_store",
+           "drop_store", "list_stores", "store_exists", "Store", "Table",
+           "snapshot"]

--- a/featherstore/connection.py
+++ b/featherstore/connection.py
@@ -66,11 +66,20 @@ def is_connected():
 
 
 def database_exists(path):
+    """Checks whether a directory is a FeatherStore database.
+
+    Parameters
+    ----------
+    path : str
+        Path to the directory to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the directory contains a FeatherStore database marker.
+    """
     db_marker_path = os.path.join(path, DB_MARKER_NAME)
-    if os.path.exists(db_marker_path):
-        return True
-    else:
-        return False
+    return os.path.exists(db_marker_path)
 
 
 class Connection:

--- a/tests/test_db_and_connection.py
+++ b/tests/test_db_and_connection.py
@@ -12,11 +12,16 @@ def test_create_database():
     fs.create_database(DB_PATH, connect=False)
     # Assert
     db_exists_after_create_db = os.path.exists(DB_PATH)
-    db_folder_is_db = DB_MARKER_NAME in os.listdir(DB_PATH)
+    db_folder_is_db = fs.database_exists(DB_PATH)
     assert db_exists_after_create_db and not before_create_db
     assert db_folder_is_db
     # Teardown
     shutil.rmtree(DB_PATH)
+
+
+def test_database_exists(create_db):
+    assert fs.database_exists(DB_PATH)
+    assert not fs.database_exists(os.path.join(DB_PATH, "missing"))
 
 
 def test_connect(create_db):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Export `database_exists()` from the top-level `featherstore` package (documented in `connection.py`).
- Fix Quickstart examples for the 0.2+ API: `rename_store(..., to=...)` and `table.exists()`.
- Mention `fs.database_exists()` in the Quickstart connection section.
- Add a connection test covering the public export.

Follow-up to #7 (merged before this commit landed).

## Test plan
- [x] `pytest tests/test_db_and_connection.py` — 11 passed
- [ ] CI on Ubuntu + macOS/Windows matrix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcce3-73c9-7dc1-8d57-9f989697798f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcce3-73c9-7dc1-8d57-9f989697798f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

