### PR TITLE
Resolve lint violations, expand index type support, and raise Polars floor

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install pytest flake8
         python -m pip install pyarrow==14.0.0
         python -m pip install pandas==2.2.0
-        python -m pip install 'polars[timezone]==1.0.0'
+        python -m pip install 'polars[timezone]==1.21.0'
     - name: Test with pytest
       run: |
         pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog
 **Warning**: This update causes some API-breaking changes:
 
 * Raised minimum Python version from 3.8 to 3.11
-* Raised dependency floors to `pandas>=2.2.0`, `polars[timezone]>=1.0.0`,
+* Raised dependency floors to `pandas>=2.2.0`, `polars[timezone]>=1.21.0`,
   and `pyarrow>=14.0.0` (upper bounds removed)
 * Renamed `Table.insert()` to `Table.insert_rows()` and
   `Table.add_columns()` to `Table.insert_columns()`
@@ -42,6 +42,15 @@ Enhancements:
 * Added Taskfile benchmark tasks: `bench:format-comparison`,
   `bench:table-operations`, and `bench:log`
 * Internal benchmark logs now write to `.dev/bmarks`
+* Broadened supported index types (decimal, float, uint, binary, duration, and
+  more) with stricter validation in `_raise_if` and `_table_utils`
+* Replaced test-suite star imports with explicit fixture imports; added `__all__`
+  to `tests/fixtures`
+* Applied ruff formatting across `featherstore`, `tests`, and `benchmarks`
+* Added e2e workflow test and shared fixtures for astype, expected-table, and
+  hardcoded-table scenarios
+* Raised minimum Polars version to 1.21.0 (first release with `n_unique()`
+  support for decimal index dtypes)
 
 Bugfixes:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ FeatherStore 0.3.0 requires:
 
 * Python >= 3.11
 * pandas >= 2.2.0
-* polars[timezone] >= 1.0.0
+* polars[timezone] >= 1.21.0
 * pyarrow >= 14.0.0
 
 These are installed automatically with `pip install featherstore`.

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -3,12 +3,12 @@ import bmark
 
 def table_header(benchmark_name, shape):
     rows, cols = shape
-    return f'{benchmark_name} (Table size: {rows:,d}, {cols:,d})'
+    return f"{benchmark_name} (Table size: {rows:,d}, {cols:,d})"
 
 
 def run_benchmark(benched, header, plot=False, **kwargs):
     bench = bmark.Benchmark(benched)
-    kwargs.pop('quiet', None)
+    kwargs.pop("quiet", None)
     result = bench.run(header=header, quiet=plot, **kwargs)
     if plot:
         result.plot()

--- a/benchmarks/format_comparison.py
+++ b/benchmarks/format_comparison.py
@@ -4,6 +4,7 @@ Runs write and read benchmarks against CSV, Feather, Parquet, Pickle, DuckDB,
 and FeatherStore using pandas as the common interface. Intended for ad-hoc
 comparisons; invoke via ``python format_comparison.py`` or ``task bench:format-comparison``.
 """
+
 from common import run_benchmark, table_header
 from format_comparison_benches import csv, duckdb, feather, fstore, parquet, pickle
 
@@ -19,7 +20,7 @@ def benchmark_writes(shape, num_partitions=0, plot=False, **kwargs):
     )
     return run_benchmark(
         benched,
-        table_header('Write benchmark', shape),
+        table_header("Write benchmark", shape),
         plot=plot,
         **kwargs,
     )
@@ -36,20 +37,20 @@ def benchmark_reads(shape, num_partitions=0, plot=False, **kwargs):
     )
     return run_benchmark(
         benched,
-        table_header('Read benchmark', shape),
+        table_header("Read benchmark", shape),
         plot=plot,
         **kwargs,
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     shape = (100_000, 6)
     num_partitions = 0
     plot = True
     run_kwargs = {
-        'n': 3,
-        'r': 5,
-        'sort': True,
+        "n": 3,
+        "r": 5,
+        "sort": True,
     }
     benchmark_writes(shape, num_partitions, plot=plot, **run_kwargs)
     benchmark_reads(shape, num_partitions, plot=plot, **run_kwargs)

--- a/benchmarks/format_comparison_benches/_fixtures.py
+++ b/benchmarks/format_comparison_benches/_fixtures.py
@@ -5,16 +5,15 @@ import bmark
 
 from table_operations_benches import _fixtures as fx
 
-BENCH_DIR = 'db'
-BENCH_MARKER = '.bmark'
+BENCH_DIR = "db"
+BENCH_MARKER = ".bmark"
 
 
 class OtherIO(bmark.Benched):
-
     def __init__(self, shape, astype):
         self._shape = shape
         self._astype = astype
-        self._path = f'{BENCH_DIR}/table_name'
+        self._path = f"{BENCH_DIR}/table_name"
         super().__init__()
 
     def setup(self):
@@ -30,10 +29,9 @@ class OtherIO(bmark.Benched):
 
 
 class ReadFileIO(OtherIO):
-
     def __init__(self, shape, extension, name):
         self.name = name
-        super().__init__(shape, astype='pandas')
+        super().__init__(shape, astype="pandas")
         self._path += extension
 
     def setup(self):
@@ -58,9 +56,9 @@ class ReadFileIO(OtherIO):
 
 def _setup():
     if os.path.exists(BENCH_DIR):
-        raise FileExistsError('Database already exists')
+        raise FileExistsError("Database already exists")
     os.makedirs(BENCH_DIR)
-    with open(os.path.join(BENCH_DIR, BENCH_MARKER), 'a'):
+    with open(os.path.join(BENCH_DIR, BENCH_MARKER), "a"):
         pass
 
 

--- a/benchmarks/format_comparison_benches/csv.py
+++ b/benchmarks/format_comparison_benches/csv.py
@@ -3,20 +3,18 @@ import pandas as pd
 
 
 class PandasWriteCsv(OtherIO):
-
     def __init__(self, shape):
-        super().__init__(shape, astype='pandas')
+        super().__init__(shape, astype="pandas")
         self.name = "Pandas write CSV"
-        self._path += '.csv'
+        self._path += ".csv"
 
     def run(self):
         self._df.to_csv(self._path)
 
 
 class PandasReadCsv(ReadFileIO):
-
     def __init__(self, shape):
-        super().__init__(shape, extension='.csv', name="Pandas read CSV")
+        super().__init__(shape, extension=".csv", name="Pandas read CSV")
 
     def run(self):
         pd.read_csv(self._path)

--- a/benchmarks/format_comparison_benches/duckdb.py
+++ b/benchmarks/format_comparison_benches/duckdb.py
@@ -4,11 +4,10 @@ import os
 
 
 class DuckdbWritePandas(OtherIO):
-
     def __init__(self, shape):
-        super().__init__(shape, astype='pandas')
+        super().__init__(shape, astype="pandas")
         self.name = "Pandas write DuckDB"
-        self._path += '.duckdb'
+        self._path += ".duckdb"
 
     def run(self):
         df = self._df  # noqa: F841
@@ -28,11 +27,10 @@ class DuckdbWritePandas(OtherIO):
 
 
 class DuckdbReadPandas(OtherIO):
-
     def __init__(self, shape):
         self.name = "Pandas read DuckDB"
-        super().__init__(shape, astype='pandas')
-        self._path += '.feather'
+        super().__init__(shape, astype="pandas")
+        self._path += ".feather"
 
     def run(self):
         self._con.execute("SELECT * from table_name").fetchdf()

--- a/benchmarks/format_comparison_benches/feather.py
+++ b/benchmarks/format_comparison_benches/feather.py
@@ -6,31 +6,31 @@ FEATHER_CHUNKSIZE = 128 * 1024**2
 
 
 class PandasWriteFeather(OtherIO):
-
     def __init__(self, shape):
-        super().__init__(shape, astype='pandas')
+        super().__init__(shape, astype="pandas")
         self.name = "Pandas write Feather"
-        self._path += '.feather'
+        self._path += ".feather"
 
     def run(self):
         feather.write_feather(
-            self._df, self._path,
+            self._df,
+            self._path,
             compression="uncompressed",
             chunksize=FEATHER_CHUNKSIZE,
         )
 
 
 class PandasReadFeather(ReadFileIO):
-
     def __init__(self, shape):
-        super().__init__(shape, extension='.feather', name="Pandas read Feather")
+        super().__init__(shape, extension=".feather", name="Pandas read Feather")
 
     def run(self):
         feather.read_feather(self._path, memory_map=True)
 
     def _write_file(self):
         feather.write_feather(
-            self._df, self._path,
+            self._df,
+            self._path,
             compression="uncompressed",
             chunksize=FEATHER_CHUNKSIZE,
         )

--- a/benchmarks/format_comparison_benches/fstore.py
+++ b/benchmarks/format_comparison_benches/fstore.py
@@ -5,7 +5,6 @@ from table_operations_benches import _fixtures as fx
 
 
 class FeatherStoreWritePandas(bmark.Benched):
-
     def __init__(self, shape, num_partitions=0):
         self.name = "Pandas write FeatherStore"
         self._shape = shape
@@ -14,30 +13,31 @@ class FeatherStoreWritePandas(bmark.Benched):
 
     def run(self):
         self._store.write_table(
-            'table_name', self._df, index='index',
+            "table_name",
+            self._df,
+            index="index",
             partition_size=self._partition_size,
         )
 
     def setup(self):
-        self._df = fx.make_table(self._shape, astype='pandas')
+        self._df = fx.make_table(self._shape, astype="pandas")
         self._partition_size = fx.get_partition_size(self._df, self._num_partitions)
-        fs.create_database('db')
+        fs.create_database("db")
 
     def teardown(self):
         fx.delete_db()
 
     def __enter__(self):
-        self._store = fs.create_store('store_name')
+        self._store = fs.create_store("store_name")
         return self
 
     def __exit__(self, exc, value, traceback):
-        self._store.drop_table('table_name')
-        fs.drop_store('store_name')
+        self._store.drop_table("table_name")
+        fs.drop_store("store_name")
 
 
 class FeatherStoreReadPandas(bmark.Benched):
-
-    def __init__(self, shape, rows=None, cols=None, name='', num_partitions=0):
+    def __init__(self, shape, rows=None, cols=None, name="", num_partitions=0):
         self.name = "Pandas read FeatherStore"
         self._shape = shape
         self._rows = rows
@@ -46,17 +46,17 @@ class FeatherStoreReadPandas(bmark.Benched):
         super().__init__()
 
     def run(self):
-        self._store.read_pandas('table_name', cols=self._cols, rows=self._rows)
+        self._store.read_pandas("table_name", cols=self._cols, rows=self._rows)
 
     def setup(self):
         df = fx.make_table(self._shape)
         partition_size = fx.get_partition_size(df, self._num_partitions)
 
-        fs.create_database('db')
-        self._store = fs.create_store('store_name')
-        self._store.write_table('table_name', df, partition_size=partition_size)
+        fs.create_database("db")
+        self._store = fs.create_store("store_name")
+        self._store.write_table("table_name", df, partition_size=partition_size)
 
     def teardown(self):
-        self._store.drop_table('table_name')
-        fs.drop_store('store_name')
+        self._store.drop_table("table_name")
+        fs.drop_store("store_name")
         fx.delete_db()

--- a/benchmarks/format_comparison_benches/parquet.py
+++ b/benchmarks/format_comparison_benches/parquet.py
@@ -3,32 +3,30 @@ import pandas as pd
 from ._fixtures import OtherIO, ReadFileIO
 
 PARQUET_KWARGS = {
-    'engine': 'pyarrow',
-    'compression': None,
-    'data_page_size': 1024,
-    'use_dictionary': False,
-    'row_group_size': 512 * 1024**2,
+    "engine": "pyarrow",
+    "compression": None,
+    "data_page_size": 1024,
+    "use_dictionary": False,
+    "row_group_size": 512 * 1024**2,
 }
 
 
 class PandasWriteParquet(OtherIO):
-
     def __init__(self, shape):
-        super().__init__(shape, astype='pandas')
+        super().__init__(shape, astype="pandas")
         self.name = "Pandas write Parquet"
-        self._path += '.parquet'
+        self._path += ".parquet"
 
     def run(self):
         self._df.to_parquet(self._path, **PARQUET_KWARGS)
 
 
 class PandasReadParquet(ReadFileIO):
-
     def __init__(self, shape):
-        super().__init__(shape, extension='.parquet', name="Pandas read Parquet")
+        super().__init__(shape, extension=".parquet", name="Pandas read Parquet")
 
     def run(self):
-        pd.read_parquet(self._path, engine='pyarrow', memory_map=True)
+        pd.read_parquet(self._path, engine="pyarrow", memory_map=True)
 
     def _write_file(self):
         self._df.to_parquet(self._path, **PARQUET_KWARGS)

--- a/benchmarks/format_comparison_benches/pickle.py
+++ b/benchmarks/format_comparison_benches/pickle.py
@@ -4,20 +4,18 @@ from ._fixtures import OtherIO, ReadFileIO
 
 
 class PandasWritePickle(OtherIO):
-
     def __init__(self, shape):
         self.name = "Pandas write Pickle"
-        super().__init__(shape, astype='pandas')
-        self._path += '.pickle'
+        super().__init__(shape, astype="pandas")
+        self._path += ".pickle"
 
     def run(self):
         self._df.to_pickle(self._path)
 
 
 class PandasReadPickle(ReadFileIO):
-
     def __init__(self, shape):
-        super().__init__(shape, extension='.pickle', name="Pandas read Pickle")
+        super().__init__(shape, extension=".pickle", name="Pandas read Pickle")
 
     def run(self):
         pd.read_pickle(self._path)

--- a/benchmarks/log_benchmarks.py
+++ b/benchmarks/log_benchmarks.py
@@ -5,6 +5,7 @@ table shapes and writes timing logs under ``.dev/bmarks``, tagged with the
 current FeatherStore version. Invoke via ``python log_benchmarks.py`` or
 ``task bench:log``.
 """
+
 import os
 
 from featherstore import __version__ as version
@@ -19,12 +20,12 @@ from table_operations import (
     write_bmark,
 )
 
-BENCHMARKS_PATH = '.dev/bmarks'
+BENCHMARKS_PATH = ".dev/bmarks"
 
 RUN_KWARGS = {
-    'n': 3,
-    'r': 6,
-    'sort': False,
+    "n": 3,
+    "r": 6,
+    "sort": False,
 }
 
 BENCH_FUNCS = [
@@ -39,15 +40,15 @@ BENCH_FUNCS = [
 
 
 def log_benchmark(shape, num_partitions, version, quiet=True):
-    run_kwargs = {**RUN_KWARGS, 'quiet': quiet}
+    run_kwargs = {**RUN_KWARGS, "quiet": quiet}
     os.makedirs(BENCHMARKS_PATH, exist_ok=True)
-    path = f'{BENCHMARKS_PATH}/Shape{shape} - Partitions({num_partitions})'
+    path = f"{BENCHMARKS_PATH}/Shape{shape} - Partitions({num_partitions})"
 
     print("Running benchmarks...")
     for func, extra_args in BENCH_FUNCS:
         print(f"Running {func.__name__} benchmark...")
         if extra_args:
-            ratio, = extra_args
+            (ratio,) = extra_args
             result = func(shape, ratio, num_partitions=num_partitions, **run_kwargs)
         else:
             result = func(shape, num_partitions=num_partitions, **run_kwargs)
@@ -56,7 +57,7 @@ def log_benchmark(shape, num_partitions, version, quiet=True):
         print(f"Logged benchmark results to {path}...")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     configs = [
         ((1_000, 10), 5),
         ((100_000, 50), 500),

--- a/benchmarks/table_operations.py
+++ b/benchmarks/table_operations.py
@@ -4,6 +4,7 @@ Covers read (full, partial rows/columns), write (sorted and unsorted), append,
 insert, update, drop, and dtype conversion. Use ``run_bmarks()`` to select a
 subset, or invoke via ``python table_operations.py`` or ``task bench:table-operations``.
 """
+
 import numpy as np
 import pyarrow as pa
 
@@ -14,7 +15,7 @@ ASTYPE_CONVERSIONS = (
     (np.int64, np.int32),
     (pa.uint32(), pa.int64()),
     (pa.float64(), pa.float32()),
-    (pa.timestamp('us'), pa.date64()),
+    (pa.timestamp("us"), pa.date64()),
     (pa.string(), pa.binary()),
     (pa.large_string(), pa.string()),
 )
@@ -36,21 +37,31 @@ def _register_read_variants(**kwargs):
 
 def read_bmark(shape, ratio=None, num_partitions=0, **kwargs):
     return _run_read_benchmark(
-        _register_read_variants, shape, num_partitions, 'Full read benchmark', **kwargs,
+        _register_read_variants,
+        shape,
+        num_partitions,
+        "Full read benchmark",
+        **kwargs,
     )
 
 
 def read_rows_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_read_benchmark(
         lambda: _configure_rows(_register_read_variants, shape, ratio),
-        shape, num_partitions, 'Partial read rows benchmark', **kwargs,
+        shape,
+        num_partitions,
+        "Partial read rows benchmark",
+        **kwargs,
     )
 
 
 def read_cols_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_read_benchmark(
         lambda: _configure_cols(_register_read_variants, shape, ratio),
-        shape, num_partitions, 'Partial read columns benchmark', **kwargs,
+        shape,
+        num_partitions,
+        "Partial read columns benchmark",
+        **kwargs,
     )
 
 
@@ -59,7 +70,8 @@ def write_bmark(shape, ratio=None, num_partitions=0, **kwargs):
     write.WritePandas(shape, num_partitions=num_partitions)
     write.WritePolars(shape, num_partitions=num_partitions)
     return write.write_bench.run(
-        header=table_header('Write benchmark', shape), **kwargs,
+        header=table_header("Write benchmark", shape),
+        **kwargs,
     )
 
 
@@ -68,7 +80,8 @@ def write_unsorted_bmark(shape, ratio=None, num_partitions=0, **kwargs):
     write.WritePandas(shape, sorted=False, num_partitions=num_partitions)
     write.WritePolars(shape, sorted=False, num_partitions=num_partitions)
     return write.write_bench.run(
-        header=table_header('Write unsorted benchmark', shape), **kwargs,
+        header=table_header("Write unsorted benchmark", shape),
+        **kwargs,
     )
 
 
@@ -80,69 +93,112 @@ def append_bmark(shape, ratio, num_partitions=0, **kwargs):
     append.AppendPolars(shape, num_rows_to_append, num_partitions=num_partitions)
 
     return append.append_bench.run(
-        table_header('Append benchmark', shape), **kwargs,
+        table_header("Append benchmark", shape),
+        **kwargs,
     )
 
 
-def _run_mutation_benchmark(bench, register, target, shape, ratio, header_name, num_partitions=0, **kwargs):
+def _run_mutation_benchmark(
+    bench, register, target, shape, ratio, header_name, num_partitions=0, **kwargs
+):
     register(target, shape, ratio, num_partitions=num_partitions)
     return bench.run(table_header(header_name, shape), **kwargs)
 
 
 def insert_rows_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        insert.insert_bench, _configure_rows, insert.Insert, shape, ratio,
-        'Insert rows benchmark', num_partitions, **kwargs,
+        insert.insert_bench,
+        _configure_rows,
+        insert.Insert,
+        shape,
+        ratio,
+        "Insert rows benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def insert_cols_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        insert.insert_bench, _configure_cols, insert.Insert, shape, ratio,
-        'Insert columns benchmark', num_partitions, **kwargs,
+        insert.insert_bench,
+        _configure_cols,
+        insert.Insert,
+        shape,
+        ratio,
+        "Insert columns benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def update_rows_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        update.update_bench, _configure_rows, update.Update, shape, ratio,
-        'Update rows benchmark', num_partitions, **kwargs,
+        update.update_bench,
+        _configure_rows,
+        update.Update,
+        shape,
+        ratio,
+        "Update rows benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def update_cols_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        update.update_bench, _configure_cols, update.Update, shape, ratio,
-        'Update columns benchmark', num_partitions, **kwargs,
+        update.update_bench,
+        _configure_cols,
+        update.Update,
+        shape,
+        ratio,
+        "Update columns benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def drop_rows_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        drop.drop_bench, _configure_rows, drop.Drop, shape, ratio,
-        'Drop rows benchmark', num_partitions, **kwargs,
+        drop.drop_bench,
+        _configure_rows,
+        drop.Drop,
+        shape,
+        ratio,
+        "Drop rows benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def drop_cols_bmark(shape, ratio, num_partitions=0, **kwargs):
     return _run_mutation_benchmark(
-        drop.drop_bench, _configure_cols, drop.Drop, shape, ratio,
-        'Drop columns benchmark', num_partitions, **kwargs,
+        drop.drop_bench,
+        _configure_cols,
+        drop.Drop,
+        shape,
+        ratio,
+        "Drop columns benchmark",
+        num_partitions,
+        **kwargs,
     )
 
 
 def astype_bmark(shape, ratio, num_partitions=0, **kwargs):
     cols = np.random.choice(range(shape[1]), round(shape[1] * ratio), replace=False)
-    cols_to_change_dtype = [f'c{n}' for n in cols]
+    cols_to_change_dtype = [f"c{n}" for n in cols]
 
     for dtype, to in ASTYPE_CONVERSIONS:
         astype.Astype(
-            shape, cols_to_change_dtype, dtype=dtype, to=to,
+            shape,
+            cols_to_change_dtype,
+            dtype=dtype,
+            to=to,
             num_partitions=num_partitions,
         )
 
     return astype.astype_bench.run(
-        table_header('Change dtype benchmark', shape), **kwargs,
+        table_header("Change dtype benchmark", shape),
+        **kwargs,
     )
 
 
@@ -152,61 +208,67 @@ def _configure_rows(module, shape, ratio, **kwargs):
     after = shape[0] - start
     rows_list = list(range(start, stop))
 
-    module(shape=shape, rows={'before': start}, name=f'(before {start:,d})', **kwargs)
-    module(shape=shape, rows={'after': after}, name=f'(after {after:,d})', **kwargs)
+    module(shape=shape, rows={"before": start}, name=f"(before {start:,d})", **kwargs)
+    module(shape=shape, rows={"after": after}, name=f"(after {after:,d})", **kwargs)
     module(
-        shape=shape, rows={'between': [start, stop]},
-        name=f'(between {start:,d}-{stop:,d})', **kwargs,
+        shape=shape,
+        rows={"between": [start, stop]},
+        name=f"(between {start:,d}-{stop:,d})",
+        **kwargs,
     )
     module(
-        shape=shape, rows=rows_list,
-        name=f'(list of {len(rows_list):,d} rows)', **kwargs,
+        shape=shape,
+        rows=rows_list,
+        name=f"(list of {len(rows_list):,d} rows)",
+        **kwargs,
     )
 
 
 def _configure_cols(module, shape, ratio, **kwargs):
-    cols = [f'c{n}' for n in range(shape[1])]
+    cols = [f"c{n}" for n in range(shape[1])]
     num_cols = round(len(cols) * ratio)
     cols = np.random.choice(cols, num_cols, replace=False)
-    module(shape=shape, cols=cols, name=f'(list of {num_cols:,d} cols)', **kwargs)
+    module(shape=shape, cols=cols, name=f"(list of {num_cols:,d} cols)", **kwargs)
 
 
 BENCHMARKS = {
-    'read': [read_bmark, read_rows_bmark, read_cols_bmark],
-    'read[full]': [read_bmark],
-    'read[rows]': [read_rows_bmark],
-    'read[cols]': [read_cols_bmark],
-    'write': [write_bmark, write_unsorted_bmark],
-    'write[sorted]': [write_bmark],
-    'write[unsorted]': [write_unsorted_bmark],
-    'append': [append_bmark],
-    'insert': [insert_rows_bmark, insert_cols_bmark],
-    'insert[rows]': [insert_rows_bmark],
-    'insert[cols]': [insert_cols_bmark],
-    'update': [update_rows_bmark, update_cols_bmark],
-    'update[rows]': [update_rows_bmark],
-    'update[cols]': [update_cols_bmark],
-    'drop': [drop_rows_bmark, drop_cols_bmark],
-    'drop[rows]': [drop_rows_bmark],
-    'drop[cols]': [drop_cols_bmark],
-    'astype': [astype_bmark],
+    "read": [read_bmark, read_rows_bmark, read_cols_bmark],
+    "read[full]": [read_bmark],
+    "read[rows]": [read_rows_bmark],
+    "read[cols]": [read_cols_bmark],
+    "write": [write_bmark, write_unsorted_bmark],
+    "write[sorted]": [write_bmark],
+    "write[unsorted]": [write_unsorted_bmark],
+    "append": [append_bmark],
+    "insert": [insert_rows_bmark, insert_cols_bmark],
+    "insert[rows]": [insert_rows_bmark],
+    "insert[cols]": [insert_cols_bmark],
+    "update": [update_rows_bmark, update_cols_bmark],
+    "update[rows]": [update_rows_bmark],
+    "update[cols]": [update_cols_bmark],
+    "drop": [drop_rows_bmark, drop_cols_bmark],
+    "drop[rows]": [drop_rows_bmark],
+    "drop[cols]": [drop_cols_bmark],
+    "astype": [astype_bmark],
 }
 
 
-def run_bmarks(shape, num_partitions, ratio=0.25, run='all', **kwargs):
-    if run == 'all':
-        funcs = list(dict.fromkeys(
-            func for bench_funcs in BENCHMARKS.values() for func in bench_funcs
-        ))
+def run_bmarks(shape, num_partitions, ratio=0.25, run="all", **kwargs):
+    if run == "all":
+        funcs = list(
+            dict.fromkeys(
+                func for bench_funcs in BENCHMARKS.values() for func in bench_funcs
+            )
+        )
     else:
         funcs = BENCHMARKS[run]
     for func in funcs:
         func(shape=shape, ratio=ratio, num_partitions=num_partitions, **kwargs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_bmarks(
-        run='all',
+        run="all",
         shape=(1_000, 12),
         num_partitions=20,
         n=3,

--- a/benchmarks/table_operations_benches/_fixtures.py
+++ b/benchmarks/table_operations_benches/_fixtures.py
@@ -12,14 +12,14 @@ import featherstore as fs
 from featherstore._utils import (
     filter_items_like_pattern,
     delete_folder_tree,
-    DB_MARKER_NAME
+    DB_MARKER_NAME,
 )
 from featherstore._table._indexers import RowIndexer
 from featherstore._table._table_utils import filter_arrow_table
 from featherstore._table.common import _format_pd_metadata
 from featherstore.table import DEFAULT_PARTITION_SIZE
 
-RANDS_CHARS = np.array(list(string.ascii_lowercase + ' '))
+RANDS_CHARS = np.array(list(string.ascii_lowercase + " "))
 
 
 def delete_db():
@@ -47,7 +47,7 @@ def _make_datetime_col(rows):
     start = -852076800  # 1943-01-01 in seconds relative to epoch
     end = 1640995200  # 2022-01-01 in seconds relative to epoch
     times_since_epoch = np.random.randint(start, end, size=rows, dtype=np.int32)
-    dtime = times_since_epoch.astype('datetime64[s]')
+    dtime = times_since_epoch.astype("datetime64[s]")
     return dtime
 
 
@@ -66,12 +66,12 @@ def _make_bool_col(rows):
 
 
 COL_DTYPES = {
-    'int': _make_int_col,
-    'string': _make_string_col,
-    'float': _make_float_col,
-    'datetime': _make_datetime_col,
-    'bool': _make_bool_col,
-    'uint': _make_uint_col,
+    "int": _make_int_col,
+    "string": _make_string_col,
+    "float": _make_float_col,
+    "datetime": _make_datetime_col,
+    "bool": _make_bool_col,
+    "uint": _make_uint_col,
 }
 
 
@@ -85,20 +85,20 @@ def make_table(shape=(30, 5), *, sorted=True, astype="arrow", dtype=None):
 
     data = dict()
     if sorted:
-        data['index'] = pd.RangeIndex(rows)
+        data["index"] = pd.RangeIndex(rows)
     else:
-        data['index'] = np.random.default_rng().permutation(rows)
+        data["index"] = np.random.default_rng().permutation(rows)
 
     for col in range(cols):
         col_dtype = next(col_dtypes)
         data[f"c{col}"] = col_dtype(rows)
-    if astype == 'pandas':
+    if astype == "pandas":
         df = pd.DataFrame.from_dict(data)
-        df.set_index('index', inplace=True)
-    elif astype in {'arrow', 'polars'}:
+        df.set_index("index", inplace=True)
+    elif astype in {"arrow", "polars"}:
         df = pa.Table.from_pydict(data)
-        df = _format_pd_metadata(df, 'index')
-        if astype == 'polars':
+        df = _format_pd_metadata(df, "index")
+        if astype == "polars":
             df = pl.from_arrow(df)
     return df
 
@@ -125,13 +125,13 @@ def get_partition_size(df, num_partitions=0):
 
 def _has_rangeindex(df):
     try:
-        index_type = df.schema.pandas_metadata['index_columns'][0]['kind']
-        return index_type == 'range'
+        index_type = df.schema.pandas_metadata["index_columns"][0]["kind"]
+        return index_type == "range"
     except TypeError:
         return False
 
 
-def split_table(df, rows=None, cols=None, index_name='index', keep_index=False):
+def split_table(df, rows=None, cols=None, index_name="index", keep_index=False):
     if isinstance(df, (pd.DataFrame, pd.Series)):
         df, other = split_pandas(df, rows, cols)
     elif isinstance(df, pa.Table):
@@ -144,7 +144,7 @@ def split_table(df, rows=None, cols=None, index_name='index', keep_index=False):
 def split_pandas(df, rows, cols):
     both_rows_and_cols_are_provided = cols is not None and rows is not None
     if both_rows_and_cols_are_provided:
-        raise AttributeError('Both cols and rows provided')
+        raise AttributeError("Both cols and rows provided")
     elif rows is not None:
         df, other = _split_pd_rows(df, rows)
     elif cols is not None:
@@ -165,7 +165,7 @@ def _split_pd_rows(df, rows):
 def split_arrow(df, rows, cols, index_name, keep_index):
     both_rows_and_cols_are_provided = cols is not None and rows is not None
     if both_rows_and_cols_are_provided:
-        raise AttributeError('Both cols and rows provided')
+        raise AttributeError("Both cols and rows provided")
     elif rows is not None:
         df, other = _split_pa_rows(df, rows, index_name)
     elif cols is not None:
@@ -185,7 +185,7 @@ def _split_pa_rows(df, rows, index_name):
 def split_polars(df, rows, cols, index_name, keep_index):
     both_rows_and_cols_are_provided = cols is not None and rows is not None
     if both_rows_and_cols_are_provided:
-        raise AttributeError('Both cols and rows provided')
+        raise AttributeError("Both cols and rows provided")
     elif rows is not None:
         df, other = _split_pl_rows(df, rows, index_name)
     elif cols is not None:
@@ -207,7 +207,7 @@ def _split_cols(df, cols, index_name=None, keep_index=False):
     df_cols = _get_cols(df)
 
     if isinstance(cols, dict):
-        pattern = cols['like']
+        pattern = cols["like"]
         cols = filter_items_like_pattern(df_cols, like=pattern)
     not_cols = [c for c in df_cols if c not in cols]
     if keep_index and not isinstance(df, (pd.DataFrame, pd.Series)):
@@ -238,7 +238,7 @@ def _split_cols(df, cols, not_cols):
     return df, other
 
 
-def update_values(df, index_name='index'):
+def update_values(df, index_name="index"):
     df = copy.copy(df)
     col_names = df.column_names if isinstance(df, pa.Table) else df.columns
     for col_name in col_names:
@@ -268,19 +268,19 @@ def _update_col(df):
 def _get_dtype(df):
     dtype = df.dtype.kind
 
-    if dtype == 'i':
+    if dtype == "i":
         if df.min() < 0:
-            dtype = 'int'
+            dtype = "int"
         else:
-            dtype = 'uint'
-    elif dtype == 'f':
-        dtype = 'float'
-    elif dtype == 'b':
-        dtype = 'bool'
-    elif dtype == 'O':
-        dtype = 'string'
-    elif dtype == 'M':
-        dtype = 'datetime'
+            dtype = "uint"
+    elif dtype == "f":
+        dtype = "float"
+    elif dtype == "b":
+        dtype = "bool"
+    elif dtype == "O":
+        dtype = "string"
+    elif dtype == "M":
+        dtype = "datetime"
 
     return dtype
 
@@ -299,7 +299,7 @@ def is_numpy_dtype(item):
         return False
 
 
-def change_dtype(df, to, index_name='index', cols=None):
+def change_dtype(df, to, index_name="index", cols=None):
     arrow_dtype = to_pa_dtype(to)
     schema = df.schema
     cols = cols if cols else schema.names

--- a/benchmarks/table_operations_benches/_helpers.py
+++ b/benchmarks/table_operations_benches/_helpers.py
@@ -8,11 +8,11 @@ def partition_size(df, num_partitions):
 
 
 def open_table():
-    fs.create_database('db')
-    store = fs.create_store('store_name')
-    return store.select_table('table_name')
+    fs.create_database("db")
+    store = fs.create_store("store_name")
+    return store.select_table("table_name")
 
 
 def close_table():
-    fs.drop_store('store_name')
+    fs.drop_store("store_name")
     fx.delete_db()

--- a/benchmarks/table_operations_benches/append.py
+++ b/benchmarks/table_operations_benches/append.py
@@ -8,10 +8,9 @@ append_bench = bmark.Benchmark()
 
 
 class AppendFS(bmark.Benched):
-
     def __init__(self, shape, rows, astype, num_partitions):
         self._shape = shape
-        self._rows = {'after': self._shape[0] - rows}
+        self._rows = {"after": self._shape[0] - rows}
         self._astype = astype
         self._num_partitions = num_partitions
 
@@ -23,10 +22,10 @@ class AppendFS(bmark.Benched):
         df, self._append_df = fx.split_table(df, rows=self._rows)
         self._partition_size = partition_size(df, self._num_partitions)
 
-        fs.create_database('db')
-        store = fs.create_store('store_name')
-        self._table = store.select_table('table_name')
-        self._table.write(df, index='index', partition_size=self._partition_size)
+        fs.create_database("db")
+        store = fs.create_store("store_name")
+        self._table = store.select_table("table_name")
+        self._table.write(df, index="index", partition_size=self._partition_size)
 
     def teardown(self):
         close_table()
@@ -37,23 +36,20 @@ class AppendFS(bmark.Benched):
 
 @append_bench()
 class AppendPandas(AppendFS):
-
     def __init__(self, shape, rows=None, num_partitions=0):
         self.name = f"FS append Pandas (list of {rows:,d} rows)"
-        super().__init__(shape, rows, astype='pandas', num_partitions=num_partitions)
+        super().__init__(shape, rows, astype="pandas", num_partitions=num_partitions)
 
 
 @append_bench()
 class AppendArrow(AppendFS):
-
     def __init__(self, shape, rows=None, num_partitions=0):
         self.name = f"FS append Arrow (list of {rows:,d} rows)"
-        super().__init__(shape, rows, astype='arrow', num_partitions=num_partitions)
+        super().__init__(shape, rows, astype="arrow", num_partitions=num_partitions)
 
 
 @append_bench()
 class AppendPolars(AppendFS):
-
     def __init__(self, shape, rows=None, num_partitions=0):
         self.name = f"FS append Polars (list of {rows:,d} rows)"
-        super().__init__(shape, rows, astype='polars', num_partitions=num_partitions)
+        super().__init__(shape, rows, astype="polars", num_partitions=num_partitions)

--- a/benchmarks/table_operations_benches/astype.py
+++ b/benchmarks/table_operations_benches/astype.py
@@ -5,23 +5,23 @@ from . import _fixtures as fx
 from ._helpers import close_table, open_table, partition_size
 
 SOURCE_DTYPE_MAP = {
-    pa.float16(): 'float',
-    pa.float32(): 'float',
-    pa.float64(): 'float',
-    pa.int16(): 'int',
-    pa.int32(): 'int',
-    pa.int64(): 'int',
-    pa.uint32(): 'uint',
-    pa.bool_(): 'bool',
-    pa.date32(): 'datetime',
-    pa.date64(): 'datetime',
-    pa.time32('ms'): 'datetime',
-    pa.time64('us'): 'datetime',
-    pa.timestamp('us'): 'datetime',
-    pa.string(): 'string',
-    pa.large_string(): 'string',
-    pa.binary(): 'string',
-    pa.large_binary(): 'string',
+    pa.float16(): "float",
+    pa.float32(): "float",
+    pa.float64(): "float",
+    pa.int16(): "int",
+    pa.int32(): "int",
+    pa.int64(): "int",
+    pa.uint32(): "uint",
+    pa.bool_(): "bool",
+    pa.date32(): "datetime",
+    pa.date64(): "datetime",
+    pa.time32("ms"): "datetime",
+    pa.time64("us"): "datetime",
+    pa.timestamp("us"): "datetime",
+    pa.string(): "string",
+    pa.large_string(): "string",
+    pa.binary(): "string",
+    pa.large_binary(): "string",
 }
 
 astype_bench = bmark.Benchmark()
@@ -29,7 +29,6 @@ astype_bench = bmark.Benchmark()
 
 @astype_bench()
 class Astype(bmark.Benched):
-
     def __init__(self, shape, cols, dtype=None, to=None, num_partitions=0):
         self._shape = shape
         self._dtype = fx.to_pa_dtype(dtype)
@@ -43,7 +42,7 @@ class Astype(bmark.Benched):
 
     def setup(self):
         source_dtype = SOURCE_DTYPE_MAP[self._dtype]
-        df = fx.make_table(self._shape, astype='arrow', dtype=source_dtype)
+        df = fx.make_table(self._shape, astype="arrow", dtype=source_dtype)
         self._df = fx.change_dtype(df, to=self._dtype)
         self._partition_size = partition_size(self._df, self._num_partitions)
         self._table = open_table()
@@ -52,7 +51,7 @@ class Astype(bmark.Benched):
         close_table()
 
     def __enter__(self):
-        self._table.write(self._df, index='index', partition_size=self._partition_size)
+        self._table.write(self._df, index="index", partition_size=self._partition_size)
         return self
 
     def __exit__(self, exc, value, traceback):

--- a/benchmarks/table_operations_benches/drop.py
+++ b/benchmarks/table_operations_benches/drop.py
@@ -8,8 +8,7 @@ drop_bench = bmark.Benchmark()
 
 @drop_bench()
 class Drop(bmark.Benched):
-
-    def __init__(self, shape, rows=None, cols=None, name='values', num_partitions=0):
+    def __init__(self, shape, rows=None, cols=None, name="values", num_partitions=0):
         self._shape = shape
         self._rows = rows
         self._cols = cols
@@ -20,7 +19,7 @@ class Drop(bmark.Benched):
         self._table.drop(rows=self._rows, cols=self._cols)
 
     def setup(self):
-        self._df = fx.make_table(self._shape, astype='arrow')
+        self._df = fx.make_table(self._shape, astype="arrow")
         self._partition_size = partition_size(self._df, self._num_partitions)
         self._table = open_table()
 
@@ -28,7 +27,7 @@ class Drop(bmark.Benched):
         close_table()
 
     def __enter__(self):
-        self._table.write(self._df, index='index', partition_size=self._partition_size)
+        self._table.write(self._df, index="index", partition_size=self._partition_size)
         return self
 
     def __exit__(self, exc, value, traceback):

--- a/benchmarks/table_operations_benches/insert.py
+++ b/benchmarks/table_operations_benches/insert.py
@@ -8,8 +8,7 @@ insert_bench = bmark.Benchmark()
 
 @insert_bench()
 class Insert(bmark.Benched):
-
-    def __init__(self, shape, rows=None, cols=None, name='values', num_partitions=0):
+    def __init__(self, shape, rows=None, cols=None, name="values", num_partitions=0):
         self._shape = shape
         self._rows = rows
         self._cols = cols
@@ -20,7 +19,7 @@ class Insert(bmark.Benched):
         self._insert(self._insert_df)
 
     def setup(self):
-        df = fx.make_table(self._shape, astype='pandas')
+        df = fx.make_table(self._shape, astype="pandas")
         self._df, self._insert_df = fx.split_table(df, rows=self._rows, cols=self._cols)
         self._partition_size = partition_size(self._df, self._num_partitions)
         self._table = open_table()
@@ -34,7 +33,7 @@ class Insert(bmark.Benched):
         close_table()
 
     def __enter__(self):
-        self._table.write(self._df, index='index', partition_size=self._partition_size)
+        self._table.write(self._df, index="index", partition_size=self._partition_size)
         return super().__enter__()
 
     def __exit__(self, exc, value, traceback):

--- a/benchmarks/table_operations_benches/read.py
+++ b/benchmarks/table_operations_benches/read.py
@@ -5,33 +5,32 @@ import featherstore as fs
 read_bench = bmark.Benchmark()
 
 
-@read_bench('setup')
+@read_bench("setup")
 def _setup(shape, num_partitions=0):
     df = fx.make_table(shape)
     partition_size = fx.get_partition_size(df, num_partitions)
 
-    fs.create_database('db')
-    store = fs.create_store('store_name')
-    store.write_table('table_name', df, partition_size=partition_size)
+    fs.create_database("db")
+    store = fs.create_store("store_name")
+    store.write_table("table_name", df, partition_size=partition_size)
 
 
-@read_bench('teardown')
+@read_bench("teardown")
 def _teardown():
-    store = fs.Store('store_name')
-    store.drop_table('table_name')
+    store = fs.Store("store_name")
+    store.drop_table("table_name")
     fx.delete_db()
 
 
 class ReadFS(bmark.Benched):
-
     def __init__(self, rows, cols, name):
         self._rows = rows
         self._cols = cols
         if name:
-            self.name = self.name + ' ' + name
+            self.name = self.name + " " + name
 
     def setup(self):
-        self._store = fs.Store('store_name')
+        self._store = fs.Store("store_name")
 
     def __enter__(self):
         return self
@@ -42,32 +41,29 @@ class ReadFS(bmark.Benched):
 
 @read_bench()
 class ReadArrow(ReadFS):
-
-    def __init__(self, *, rows=None, cols=None, name='', **kwargs):
+    def __init__(self, *, rows=None, cols=None, name="", **kwargs):
         self.name = "FS read Arrow"
         super().__init__(rows, cols, name)
 
     def run(self):
-        self._store.read_arrow('table_name', cols=self._cols, rows=self._rows)
+        self._store.read_arrow("table_name", cols=self._cols, rows=self._rows)
 
 
 @read_bench()
 class ReadPandas(ReadFS):
-
-    def __init__(self, *, rows=None, cols=None, name='', **kwargs):
+    def __init__(self, *, rows=None, cols=None, name="", **kwargs):
         self.name = "FS read Pandas"
         super().__init__(rows, cols, name)
 
     def run(self):
-        self._store.read_pandas('table_name', cols=self._cols, rows=self._rows)
+        self._store.read_pandas("table_name", cols=self._cols, rows=self._rows)
 
 
 @read_bench()
 class ReadPolars(ReadFS):
-
-    def __init__(self, *, rows=None, cols=None, name='', **kwargs):
+    def __init__(self, *, rows=None, cols=None, name="", **kwargs):
         self.name = "FS read Polars"
         super().__init__(rows, cols, name)
 
     def run(self):
-        self._store.read_polars('table_name', cols=self._cols, rows=self._rows)
+        self._store.read_polars("table_name", cols=self._cols, rows=self._rows)

--- a/benchmarks/table_operations_benches/update.py
+++ b/benchmarks/table_operations_benches/update.py
@@ -8,8 +8,7 @@ update_bench = bmark.Benchmark()
 
 @update_bench()
 class Update(bmark.Benched):
-
-    def __init__(self, shape, rows=None, cols=None, name='values', num_partitions=0):
+    def __init__(self, shape, rows=None, cols=None, name="values", num_partitions=0):
         self._shape = shape
         self._rows = rows
         self._cols = cols
@@ -20,7 +19,7 @@ class Update(bmark.Benched):
         self._table.update(self._update_df)
 
     def setup(self):
-        self._df = fx.make_table(self._shape, astype='pandas')
+        self._df = fx.make_table(self._shape, astype="pandas")
         _, update_df = fx.split_table(self._df, rows=self._rows, cols=self._cols)
         self._update_df = fx.update_values(update_df)
         self._partition_size = partition_size(self._df, self._num_partitions)

--- a/benchmarks/table_operations_benches/write.py
+++ b/benchmarks/table_operations_benches/write.py
@@ -6,7 +6,6 @@ write_bench = bmark.Benchmark()
 
 
 class WriteFS(bmark.Benched):
-
     def __init__(self, shape, astype, num_partitions, sorted):
         self._shape = shape
         self._astype = astype
@@ -15,49 +14,53 @@ class WriteFS(bmark.Benched):
         super().__init__()
 
     def run(self):
-        self._store.write_table('table_name', self._df, index='index',
-                                partition_size=self._partition_size,
-                                warnings='ignore')
+        self._store.write_table(
+            "table_name",
+            self._df,
+            index="index",
+            partition_size=self._partition_size,
+            warnings="ignore",
+        )
 
     def setup(self):
         self._df = fx.make_table(self._shape, sorted=self.sorted, astype=self._astype)
         self._partition_size = fx.get_partition_size(self._df, self._num_partitions)
-        fs.create_database('db')
+        fs.create_database("db")
 
     def teardown(self):
         fx.delete_db()
 
     def __enter__(self):
-        self._store = fs.create_store('store_name')
+        self._store = fs.create_store("store_name")
         return self
 
     def __exit__(self, exc, value, traceback):
-        self._store.drop_table('table_name')
-        fs.drop_store('store_name')
+        self._store.drop_table("table_name")
+        fs.drop_store("store_name")
 
 
 @write_bench()
 class WriteArrow(WriteFS):
-
     def __init__(self, shape, num_partitions=0, sorted=True):
         self.name = "FS write Arrow"
-        super().__init__(shape, astype='arrow', num_partitions=num_partitions,
-                         sorted=sorted)
+        super().__init__(
+            shape, astype="arrow", num_partitions=num_partitions, sorted=sorted
+        )
 
 
 @write_bench()
 class WritePandas(WriteFS):
-
     def __init__(self, shape, num_partitions=0, sorted=True):
         self.name = "FS write Pandas"
-        super().__init__(shape, astype='pandas', num_partitions=num_partitions,
-                         sorted=sorted)
+        super().__init__(
+            shape, astype="pandas", num_partitions=num_partitions, sorted=sorted
+        )
 
 
 @write_bench()
 class WritePolars(WriteFS):
-
     def __init__(self, shape, num_partitions=0, sorted=True):
         self.name = "FS write Polars"
-        super().__init__(shape, astype='polars', num_partitions=num_partitions,
-                         sorted=sorted)
+        super().__init__(
+            shape, astype="polars", num_partitions=num_partitions, sorted=sorted
+        )

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -48,7 +48,7 @@ Dependency requirements
 FeatherStore 0.3.0 requires:
 
 * pandas >= 2.2.0
-* polars[timezone] >= 1.0.0
+* polars[timezone] >= 1.21.0
 * pyarrow >= 14.0.0
 
 These are installed automatically with ``pip install featherstore``.

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -31,7 +31,7 @@ Requirements
 FeatherStore 0.3.0 requires Python 3.11 or newer and the following packages:
 
 * pandas >= 2.2.0
-* polars[timezone] >= 1.0.0
+* polars[timezone] >= 1.21.0
 * pyarrow >= 14.0.0
 
 Starting Up

--- a/featherstore/__init__.py
+++ b/featherstore/__init__.py
@@ -18,7 +18,19 @@ from featherstore.table import Table
 from featherstore import snapshot
 
 __version__ = "0.3.0"
-__all__ = ["connect", "disconnect", "create_database", "current_db",
-           "is_connected", "database_exists", "create_store", "rename_store",
-           "drop_store", "list_stores", "store_exists", "Store", "Table",
-           "snapshot"]
+__all__ = [
+    "connect",
+    "disconnect",
+    "create_database",
+    "current_db",
+    "is_connected",
+    "database_exists",
+    "create_store",
+    "rename_store",
+    "drop_store",
+    "list_stores",
+    "store_exists",
+    "Store",
+    "Table",
+    "snapshot",
+]

--- a/featherstore/_metadata.py
+++ b/featherstore/_metadata.py
@@ -5,19 +5,18 @@ from featherstore import _utils
 METADATA_FOLDER_NAME = ".metadata"
 
 
-class Metadata():
-
+class Metadata:
     def __init__(self, path, file_name):
         _can_init_metadata(path, file_name)
         self._metadata_folder = os.path.join(path, METADATA_FOLDER_NAME)
-        self._db_path = os.path.join(self._metadata_folder, file_name) + '.db'
+        self._db_path = os.path.join(self._metadata_folder, file_name) + ".db"
         self.index = KeyIndex(self._metadata_folder, file_name)
 
     def create(self):
         if not os.path.exists(self._metadata_folder):
             os.makedirs(self._metadata_folder)
             _utils.mark_as_hidden(self._metadata_folder)
-            _utils.touch(self._db_path, flag='ab')
+            _utils.touch(self._db_path, flag="ab")
 
     def write(self, new_data: dict):
         _can_write_metadata(new_data)
@@ -74,9 +73,8 @@ class Metadata():
 
 
 class KeyIndex:
-
     def __init__(self, metadata_folder, file_name):
-        self._path = os.path.join(metadata_folder, file_name) + '.index'
+        self._path = os.path.join(metadata_folder, file_name) + ".index"
         if os.path.exists(self._path):
             self._data, self._db_size = self._read_data()
         else:
@@ -107,12 +105,12 @@ class KeyIndex:
         return len(self._data)
 
     def _write_data(self):
-        with open(self._path, 'wb') as f:
+        with open(self._path, "wb") as f:
             pickle.dump(self._data, f)
             pickle.dump(self._db_size, f)
 
     def _read_data(self):
-        with open(self._path, 'rb') as f:
+        with open(self._path, "rb") as f:
             data = pickle.load(f)
             size = pickle.load(f)
         return data, size

--- a/featherstore/_table/_indexers.py
+++ b/featherstore/_table/_indexers.py
@@ -7,9 +7,8 @@ from featherstore._table import _table_utils
 
 
 class Indexer:
-
     def __init__(self, items, keywords):
-        if hasattr(items, 'copy'):
+        if hasattr(items, "copy"):
             items = items.copy()
 
         if isinstance(items, dict):
@@ -41,9 +40,9 @@ class Indexer:
 
         if isinstance(items, list):
             _values = items
-        elif hasattr(items, 'tolist'):
+        elif hasattr(items, "tolist"):
             _values = items.tolist()
-        elif hasattr(items, 'to_list'):
+        elif hasattr(items, "to_list"):
             _values = items.to_list()
         else:
             _values = list(items)
@@ -123,16 +122,17 @@ class Indexer:
 
     def __repr__(self):
         class_name = str(self.__class__)
-        class_name = class_name.split('.')[-1]
-        class_name = class_name.replace("'>", '')
-        return f"{class_name}(Keys: {self.keys()} | Values: {self.values()} |" \
-               f" Keyword: {self.keyword})"
+        class_name = class_name.split(".")[-1]
+        class_name = class_name.replace("'>", "")
+        return (
+            f"{class_name}(Keys: {self.keys()} | Values: {self.values()} |"
+            f" Keyword: {self.keyword})"
+        )
 
 
 class RowIndexer(Indexer):
-
     def __init__(self, rows):
-        super().__init__(rows, keywords=('before', 'after', 'between'))
+        super().__init__(rows, keywords=("before", "after", "between"))
 
     def convert_types(self, *, to):
         formatted_rows = self.copy()
@@ -155,9 +155,8 @@ class RowIndexer(Indexer):
 
 
 class ColIndexer(Indexer):
-
     def __init__(self, cols):
-        super().__init__(cols, keywords=['like'])
+        super().__init__(cols, keywords=["like"])
 
     def like(self, stored_cols):
         if self.keyword:

--- a/featherstore/_table/_raise_if.py
+++ b/featherstore/_table/_raise_if.py
@@ -1,5 +1,6 @@
 import os
-from numbers import Integral
+from decimal import Decimal
+from numbers import Integral, Real
 
 import pandas as pd
 import polars as pl
@@ -18,15 +19,14 @@ def table_not_exists(table):
 
 
 def table_already_exists(table_path):
-    table_name = table_path.rsplit('/')[-1]
+    table_name = table_path.rsplit("/")[-1]
     if os.path.exists(table_path):
         raise FileExistsError(f"A table with name '{table_name}' already exists")
 
 
 def table_name_is_not_str(table_name):
     if not isinstance(table_name, str):
-        raise TypeError(
-            f"'table_name' must be a str (is type {type(table_name)})")
+        raise TypeError(f"'table_name' must be a str (is type {type(table_name)})")
 
 
 def table_name_is_forbidden(table_name):
@@ -41,7 +41,9 @@ def df_is_not_supported_table_type(df):
 
 def df_is_not_pandas_table(df):
     if not isinstance(df, (pd.DataFrame, pd.Series)):
-        raise TypeError(f"'df' must be a pd.DataFrame or pd.Series (is type {type(df)})")
+        raise TypeError(
+            f"'df' must be a pd.DataFrame or pd.Series (is type {type(df)})"
+        )
 
 
 def rows_argument_is_not_collection(rows):
@@ -92,7 +94,9 @@ def cols_argument_items_is_not_str_or_none(cols):
 
 def length_of_cols_and_to_doesnt_match(cols, to):
     if len(cols) != len(to):
-        raise ValueError(f"Length of 'cols' != length of 'to' ({len(cols)} != {len(to)})")
+        raise ValueError(
+            f"Length of 'cols' != length of 'to' ({len(cols)} != {len(to)})"
+        )
 
 
 def cols_does_not_match(df, table_data):
@@ -119,9 +123,11 @@ def to_is_provided_twice(cols, to):
     cols_is_dict = isinstance(cols, dict)
     to_is_provided = to is not None
     if cols_is_dict and to_is_provided:
-        raise AttributeError("'to' is provided twice, use either "
-                             "'cols={<COL>: <TO>, ...}, to=None' "
-                             "or 'cols=[<COL>, ...], to=[<TO>, ...]'")
+        raise AttributeError(
+            "'to' is provided twice, use either "
+            "'cols={<COL>: <TO>, ...}, to=None' "
+            "or 'cols=[<COL>, ...], to=[<TO>, ...]'"
+        )
 
 
 def to_not_provided(cols, to):
@@ -149,18 +155,27 @@ def rows_argument_items_type_not_same_as_index(rows, table_data):
 
 def _rows_type_matches_index(rows, index_dtype):
     row = rows[0]
-
-    matches_dtime_idx = _check_if_row_and_index_is_temporal(row, index_dtype)
-    matches_str_idx = _check_if_row_and_index_is_str(row, index_dtype)
-    matches_int_idx = _check_if_row_and_index_is_int(row, index_dtype)
-
-    row_type_matches_idx = matches_dtime_idx or matches_str_idx or matches_int_idx
-    return row_type_matches_idx
+    checks = (
+        _check_if_row_and_index_is_temporal,
+        _check_if_row_and_index_is_duration,
+        _check_if_row_and_index_is_str,
+        _check_if_row_and_index_is_binary,
+        _check_if_row_and_index_is_int,
+        _check_if_row_and_index_is_float,
+        _check_if_row_and_index_is_decimal,
+    )
+    return any(check(row, index_dtype) for check in checks)
 
 
 def _check_if_row_and_index_is_temporal(row, index_dtype):
     if _table_utils.typestring_is_temporal(index_dtype):
         return _isinstance_temporal(row)
+    return False
+
+
+def _check_if_row_and_index_is_duration(row, index_dtype):
+    if _table_utils.typestring_is_duration(index_dtype):
+        return _isinstance_duration(row)
     return False
 
 
@@ -170,9 +185,27 @@ def _check_if_row_and_index_is_str(row, index_dtype):
     return False
 
 
+def _check_if_row_and_index_is_binary(row, index_dtype):
+    if _table_utils.typestring_is_binary(index_dtype):
+        return _isinstance_binary(row)
+    return False
+
+
 def _check_if_row_and_index_is_int(row, index_dtype):
     if _table_utils.typestring_is_int(index_dtype):
         return _isinstance_int(row)
+    return False
+
+
+def _check_if_row_and_index_is_float(row, index_dtype):
+    if _table_utils.typestring_is_float(index_dtype):
+        return _isinstance_float(row)
+    return False
+
+
+def _check_if_row_and_index_is_decimal(row, index_dtype):
+    if _table_utils.typestring_is_decimal(index_dtype):
+        return _isinstance_decimal(row)
     return False
 
 
@@ -198,12 +231,41 @@ def _isinstance_str(obj):
     return is_str
 
 
+def _isinstance_duration(obj):
+    return isinstance(obj, pd.Timedelta)
+
+
 def _isinstance_int(obj):
     try:
         is_int = pa.types.is_integer(obj)
     except AttributeError:
         is_int = isinstance(obj, Integral)
     return is_int
+
+
+def _isinstance_float(obj):
+    return isinstance(obj, Real) and not isinstance(obj, (Integral, bool))
+
+
+def _isinstance_decimal(obj):
+    return isinstance(obj, Decimal)
+
+
+def _isinstance_binary(obj):
+    return isinstance(obj, (bytes, bytearray))
+
+
+def index_type_not_supported(index_or_dtype):
+    if index_or_dtype is None:
+        return
+    if isinstance(index_or_dtype, pa.DataType):
+        index_type = index_or_dtype
+    elif hasattr(index_or_dtype, "type"):
+        index_type = index_or_dtype.type
+    else:
+        index_type = index_or_dtype
+    if not _table_utils.index_type_is_supported(index_type):
+        raise TypeError(f"Table.index type is not supported (is type {index_type})")
 
 
 def index_type_not_same_as_stored_index(df, table_data):
@@ -215,7 +277,7 @@ def index_type_not_same_as_stored_index(df, table_data):
 
 
 def index_name_not_same_as_stored_index(df, table_data):
-    stored_index_name = table_data['index_name']
+    stored_index_name = table_data["index_name"]
     has_default_index = table_data["has_default_index"]
     cols = _table_utils.get_col_names(df, has_default_index=has_default_index)
     if stored_index_name not in cols:

--- a/featherstore/_table/_table_utils.py
+++ b/featherstore/_table/_table_utils.py
@@ -141,8 +141,7 @@ def _combine_small_partitions(partitions, partition_size):
 
     if has_multiple_partitions and size_of_last_partition < min_partition_size:
         new_last_partition = _combine_last_two_partitions(partitions)
-        partitions = _replace_last_two_partitions(new_last_partition,
-                                                  partitions)
+        partitions = _replace_last_two_partitions(new_last_partition, partitions)
     return partitions
 
 
@@ -160,7 +159,7 @@ def _replace_last_two_partitions(new_last_partition, partitions):
 
 def convert_int_to_partition_id(partition_id):
     partition_id = int(partition_id * INSERTION_BUFFER_LENGTH)
-    format_string = f'0{PARTITION_NAME_LENGTH}d'
+    format_string = f"0{PARTITION_NAME_LENGTH}d"
     partition_id = format(partition_id, format_string)
     return partition_id
 
@@ -199,13 +198,13 @@ def assign_ids_to_partitions(df, ids):
 
 def get_first_stored_index_value(partition_metadata):
     first_partition = partition_metadata.keys()[0]
-    first_stored_value = partition_metadata[first_partition]['min']
+    first_stored_value = partition_metadata[first_partition]["min"]
     return first_stored_value
 
 
 def get_last_stored_index_value(partition_metadata):
     last_partition = partition_metadata.keys()[-1]
-    last_stored_value = partition_metadata[last_partition]['max']
+    last_stored_value = partition_metadata[last_partition]["max"]
     return last_stored_value
 
 
@@ -214,7 +213,7 @@ def get_index_name(df):
     if pd_metadata is None:
         no_index_name = True
     else:
-        index_name, = pd_metadata["index_columns"]
+        (index_name,) = pd_metadata["index_columns"]
         no_index_name = not isinstance(index_name, str)
 
     if no_index_name:
@@ -233,12 +232,66 @@ def typestring_is_temporal(index_dtype):
     return "time" in index_dtype or "date" in index_dtype
 
 
+def typestring_is_duration(index_dtype):
+    return "duration" in index_dtype
+
+
 def typestring_is_string(index_dtype):
     return "string" in index_dtype
 
 
 def typestring_is_int(index_dtype):
-    return "int" in index_dtype
+    return index_dtype.startswith(("int", "uint"))
+
+
+def typestring_is_float(index_dtype):
+    return (
+        "float" in index_dtype or "double" in index_dtype or "halffloat" in index_dtype
+    )
+
+
+def typestring_is_decimal(index_dtype):
+    return "decimal" in index_dtype
+
+
+def typestring_is_binary(index_dtype):
+    return "binary" in index_dtype
+
+
+def index_type_is_supported(index_type):
+    if isinstance(index_type, pa.DataType):
+        return _pa_index_type_is_supported(index_type)
+    return _index_typestring_is_supported(str(index_type))
+
+
+def _pa_index_type_is_supported(dtype):
+    return any(
+        check(dtype)
+        for check in (
+            pa.types.is_integer,
+            pa.types.is_floating,
+            pa.types.is_decimal,
+            pa.types.is_binary,
+            pa.types.is_string,
+            pa.types.is_large_string,
+            pa.types.is_temporal,
+        )
+    )
+
+
+def _index_typestring_is_supported(index_dtype):
+    return any(
+        check(index_dtype)
+        for check in (
+            typestring_is_string,
+            typestring_is_temporal,
+            typestring_is_duration,
+            typestring_is_int,
+            typestring_is_float,
+            typestring_is_decimal,
+            typestring_is_binary,
+        )
+    )
 
 
 def get_index_if_exists(df, index_name):
@@ -256,11 +309,11 @@ def filter_arrow_table(df, rows, index_col_name):
     index = df[index_col_name]
     if not rows.keyword:
         df = _fetch_rows_in_list(df, index, rows.values())
-    elif rows.keyword == 'before':
+    elif rows.keyword == "before":
         df = _fetch_rows_before(df, index, rows[0])
-    elif rows.keyword == 'after':
+    elif rows.keyword == "after":
         df = _fetch_rows_after(df, index, rows[0])
-    elif rows.keyword == 'between':
+    elif rows.keyword == "between":
         df = _fetch_rows_between(df, index, low=rows[0], high=rows[1])
     return df
 
@@ -277,7 +330,7 @@ def _fetch_rows_in_list(df, index, rows):
 def _raise_if_rows_not_in_table(row_indices):
     contains_null = row_indices.null_count > 0
     if contains_null:
-        raise IndexError('Trying to access a row not found in table')
+        raise IndexError("Trying to access a row not found in table")
 
 
 def _fetch_rows_before(df, index, row):
@@ -357,6 +410,6 @@ def is_list_like(obj):
 
 
 def is_transposed(df):
-    fs_metadata = df.schema.metadata[b'featherstore']
+    fs_metadata = df.schema.metadata[b"featherstore"]
     fs_metadata = json.loads(fs_metadata)
-    return fs_metadata['transposed']
+    return fs_metadata["transposed"]

--- a/featherstore/_table/append.py
+++ b/featherstore/_table/append.py
@@ -22,8 +22,8 @@ def can_append_table(table, df, warnings):
     _raise_if.index_type_not_same_as_stored_index(df, table_data)
     _raise_if.cols_does_not_match(df, table_data)
 
-    has_default_index = table_data['has_default_index']
-    index_name = table_data['index_name']
+    has_default_index = table_data["has_default_index"]
+    index_name = table_data["index_name"]
 
     index = _table_utils.get_index_if_exists(df, index_name)
     index_is_provided = index is not None
@@ -43,13 +43,14 @@ def _raise_if_append_data_not_ordered_after_stored_data(index, partition_data):
     if append_data_start <= stored_data_end:
         raise ValueError(
             f"New_data.index can't be <= old_data.index[-1] ({append_data_start}"
-            f" <= {stored_data_end})")
+            f" <= {stored_data_end})"
+        )
 
 
 def _get_last_stored_value(partition_data):
     df = partition_data
     last_partition_name = df.keys()[-1]
-    stored_data_end = df[last_partition_name]['max']
+    stored_data_end = df[last_partition_name]["max"]
     return stored_data_end
 
 
@@ -81,7 +82,8 @@ def append_data(df, *, to):
 
 def create_partitions(df, rows_per_partition, last_partition_name):
     partitions = _table_utils.make_partitions(df, rows_per_partition)
-    new_partition_names = _table_utils.append_new_partition_ids(len(partitions),
-                                                                [last_partition_name])
+    new_partition_names = _table_utils.append_new_partition_ids(
+        len(partitions), [last_partition_name]
+    )
     partitions = _table_utils.assign_ids_to_partitions(partitions, new_partition_names)
     return partitions

--- a/featherstore/_table/astype.py
+++ b/featherstore/_table/astype.py
@@ -28,7 +28,9 @@ def can_change_type(table, cols, astype):
 
 
 def _raise_if_astype_items_are_not_pa_or_np_types(astype):
-    col_elements_are_arrow_types = all(isinstance(item, (pa.DataType)) for item in astype)
+    col_elements_are_arrow_types = all(
+        isinstance(item, (pa.DataType)) for item in astype
+    )
     col_elements_are_np_types = all(__is_valid_dtype(item) for item in astype)
 
     if not (col_elements_are_arrow_types or col_elements_are_np_types):
@@ -44,19 +46,9 @@ def __is_valid_dtype(item):
 
 
 def _raise_if_new_index_type_is_not_valid(cols, table_data):
-    index_name = table_data['index_name']
+    index_name = table_data["index_name"]
     if index_name in cols.keys():
-        new_index_dtype = cols[index_name]
-        __raise_if_index_is_not_supported_type(new_index_dtype)
-
-
-def __raise_if_index_is_not_supported_type(dtype):
-    is_integer = pa.types.is_integer(dtype)
-    is_temporal = pa.types.is_temporal(dtype)
-    is_string = pa.types.is_string(dtype) or pa.types.is_large_string(dtype)
-    if not is_integer and not is_temporal and not is_string:
-        raise TypeError(f"Table.index type must be either int, str or "
-                        f"datetime (is type {dtype})")
+        _raise_if.index_type_not_supported(cols[index_name])
 
 
 def change_type(df, cols):
@@ -88,7 +80,7 @@ def create_partitions(df, rows_per_partition, partition_names=None):
 
 def _add_or_remove_partition_ids(partitions, partition_ids):
     if len(partitions) < len(partition_ids):
-        partition_ids = partition_ids[:len(partitions)]
+        partition_ids = partition_ids[: len(partitions)]
     else:
         partition_ids = _table_utils.add_new_partition_ids(partitions, partition_ids)
     return partition_ids

--- a/featherstore/_table/common.py
+++ b/featherstore/_table/common.py
@@ -10,10 +10,10 @@ from featherstore._table._indexers import ColIndexer, RowIndexer
 
 HAS_MULTI_TYPE_COLUMN = (pa.lib.ArrowTypeError, pa.lib.ArrowInvalid)
 
-_STRING_ARROW_TYPES = {'string', 'utf8', 'large_string', 'large_utf8'}
-_PANDAS_MAJOR = int(pd.__version__.split('.', 1)[0])
+_STRING_ARROW_TYPES = {"string", "utf8", "large_string", "large_utf8"}
+_PANDAS_MAJOR = int(pd.__version__.split(".", 1)[0])
 _STRING_PANDAS_TYPE, _STRING_NUMPY_TYPE = (
-    ('object', 'str') if _PANDAS_MAJOR >= 3 else ('unicode', 'string')
+    ("object", "str") if _PANDAS_MAJOR >= 3 else ("unicode", "string")
 )
 
 
@@ -67,7 +67,9 @@ def _transpose_table_and_convert_to_arrow(df):
     try:
         df = _table_utils.convert_to_arrow(df)
     except HAS_MULTI_TYPE_COLUMN:
-        raise ValueError("Cannot convert table with multiple dtypes in same column to arrow.")
+        raise ValueError(
+            "Cannot convert table with multiple dtypes in same column to arrow."
+        )
     new_metadata = json.dumps({"transposed": True})
     df = _add_featherstore_metadata(df, new_metadata)
     return df
@@ -126,15 +128,19 @@ def _format_pd_metadata(df, index_name):
 def _make_pd_metadata(df, index_name):
     metadata = dict()
 
-    metadata['index_columns'] = [index_name]
-    metadata['column_indexes'] = [{'name': None, 'field_name': None,
-                                   'pandas_type': 'unicode',
-                                   'numpy_type': 'object',
-                                   'metadata': {'encoding': 'UTF-8'}}
-                                  ]
-    metadata['columns'] = [__make_column_metadata(df, col) for col in df.column_names]
+    metadata["index_columns"] = [index_name]
+    metadata["column_indexes"] = [
+        {
+            "name": None,
+            "field_name": None,
+            "pandas_type": "unicode",
+            "numpy_type": "object",
+            "metadata": {"encoding": "UTF-8"},
+        }
+    ]
+    metadata["columns"] = [__make_column_metadata(df, col) for col in df.column_names]
     metadata = json.dumps(metadata)
-    metadata = {b'pandas': metadata}
+    metadata = {b"pandas": metadata}
     return metadata
 
 
@@ -145,12 +151,13 @@ def __make_column_metadata(df, col):
     np_dtype, extra_data = __get_numpy_dtype_info(dtype, column)
     pd_dtype, np_dtype = _adjust_string_metadata(dtype, pd_dtype, np_dtype)
 
-    metadata = {"name": col,
-                "field_name": col,
-                "pandas_type": pd_dtype,
-                "numpy_type": np_dtype,
-                "metadata": extra_data,
-                }
+    metadata = {
+        "name": col,
+        "field_name": col,
+        "pandas_type": pd_dtype,
+        "numpy_type": np_dtype,
+        "metadata": extra_data,
+    }
     return metadata
 
 
@@ -163,31 +170,31 @@ def _adjust_string_metadata(dtype, pd_dtype, np_dtype):
 def __get_numpy_dtype_info(dtype, column=None):
     pd_dtype = pc.get_logical_type(dtype)
 
-    if pd_dtype == 'decimal':
-        numpy_dtype = 'object'
+    if pd_dtype == "decimal":
+        numpy_dtype = "object"
         extra_metadata = {
-            'precision': dtype.precision,
-            'scale': dtype.scale,
+            "precision": dtype.precision,
+            "scale": dtype.scale,
         }
-    elif pd_dtype in ('date', 'time'):
-        numpy_dtype = f'datetime64[{_arrow_temporal_resolution(dtype)}]'
+    elif pd_dtype in ("date", "time"):
+        numpy_dtype = f"datetime64[{_arrow_temporal_resolution(dtype)}]"
         extra_metadata = None
-    elif pd_dtype == 'datetime' or str(dtype).startswith('timestamp'):
+    elif pd_dtype == "datetime" or str(dtype).startswith("timestamp"):
         resolution = _arrow_temporal_resolution(dtype)
-        numpy_dtype = f'datetime64[{resolution}]'
-        tz = getattr(dtype, 'tz', None)
+        numpy_dtype = f"datetime64[{resolution}]"
+        tz = getattr(dtype, "tz", None)
         if tz is not None:
-            extra_metadata = {'timezone': pa.lib.tzinfo_to_string(tz)}
+            extra_metadata = {"timezone": pa.lib.tzinfo_to_string(tz)}
         else:
             extra_metadata = None
-    elif pd_dtype[:4] == 'list':
-        numpy_dtype = 'object'
+    elif pd_dtype[:4] == "list":
+        numpy_dtype = "object"
         extra_metadata = None
-    elif pd_dtype == 'categorical':
+    elif pd_dtype == "categorical":
         numpy_dtype = str(dtype.index_type)
         extra_metadata = {
-            'num_categories': __categorical_num_categories(column),
-            'ordered': dtype.ordered,
+            "num_categories": __categorical_num_categories(column),
+            "ordered": dtype.ordered,
         }
     else:
         numpy_dtype = _arrow_type_to_numpy_type(dtype)
@@ -207,15 +214,15 @@ def __categorical_num_categories(column):
 def _arrow_type_to_numpy_type(dtype):
     arrow_type = str(dtype)
     mapping = {
-        'double': 'float64',
-        'float': 'float32',
-        'halffloat': 'float16',
-        'string': 'str',
-        'utf8': 'str',
-        'large_string': 'str',
-        'large_utf8': 'str',
-        'binary': 'object',
-        'large_binary': 'object',
+        "double": "float64",
+        "float": "float32",
+        "halffloat": "float16",
+        "string": "str",
+        "utf8": "str",
+        "large_string": "str",
+        "large_utf8": "str",
+        "binary": "object",
+        "large_binary": "object",
     }
     return mapping.get(arrow_type, arrow_type)
 
@@ -223,9 +230,9 @@ def _arrow_type_to_numpy_type(dtype):
 def _add_pd_metadata(df, metadata):
     old_metadata = df.schema.metadata
     if old_metadata:
-        old_metadata[b'pandas'] = metadata[b'pandas']
+        old_metadata[b"pandas"] = metadata[b"pandas"]
     else:
-        old_metadata = {b'pandas': metadata[b'pandas']}
+        old_metadata = {b"pandas": metadata[b"pandas"]}
     df = df.replace_schema_metadata(old_metadata)
     return df
 
@@ -254,7 +261,8 @@ def compute_rows_per_partition(df, target_size):
 def update_metadata(table, df, old_partition_names, **kwargs):
     new_partition_metadata = _make_partition_metadata(df)
     table_metadata = _compute_table_metadata_update(
-        table, new_partition_metadata, old_partition_names)
+        table, new_partition_metadata, old_partition_names
+    )
     for key, value in kwargs.items():
         table_metadata[key] = value
     return table_metadata, new_partition_metadata
@@ -267,9 +275,9 @@ def _make_partition_metadata(df):
     index_col_name = _table_utils.get_index_name(first_partition)
     for name, partition in df.items():
         data = {
-            'min': _get_index_min(partition, index_col_name),
-            'max': _get_index_max(partition, index_col_name),
-            'num_rows': partition.num_rows
+            "min": _get_index_min(partition, index_col_name),
+            "max": _get_index_max(partition, index_col_name),
+            "num_rows": partition.num_rows,
         }
         metadata[name] = data
     return metadata
@@ -293,11 +301,14 @@ def _get_index_max(df, index_name):
 
 def _compute_table_metadata_update(table, new_partitions_data, dropped_partitions):
     dropped_partitions_data = _get_dropped_partitions_data(
-        table._partition_data, dropped_partitions)
-    num_rows = table._table_data['num_rows']
+        table._partition_data, dropped_partitions
+    )
+    num_rows = table._table_data["num_rows"]
     num_rows += _update_num_rows(dropped_partitions_data, new_partitions_data)
-    num_partitions = table._table_data['num_partitions']
-    num_partitions += _update_num_partitions(dropped_partitions_data, new_partitions_data)
+    num_partitions = table._table_data["num_partitions"]
+    num_partitions += _update_num_partitions(
+        dropped_partitions_data, new_partitions_data
+    )
 
     return {
         "num_partitions": num_partitions,
@@ -306,9 +317,9 @@ def _compute_table_metadata_update(table, new_partitions_data, dropped_partition
 
 
 def _arrow_temporal_resolution(dtype):
-    resolution = str(dtype).split('[')[-1].split(']')[0]
-    if resolution == 'day':
-        resolution = 'D'
+    resolution = str(dtype).split("[")[-1].split("]")[0]
+    if resolution == "day":
+        resolution = "D"
     return resolution
 
 
@@ -318,8 +329,8 @@ def _get_dropped_partitions_data(partition_data, partition_names):
 
 
 def _update_num_rows(dropped_partitions_data, new_partitions_data):
-    dropped = (item['num_rows'] for item in dropped_partitions_data.values())
-    added = (item['num_rows'] for item in new_partitions_data.values())
+    dropped = (item["num_rows"] for item in dropped_partitions_data.values())
+    added = (item["num_rows"] for item in new_partitions_data.values())
     return sum(added) - sum(dropped)
 
 

--- a/featherstore/_table/drop.py
+++ b/featherstore/_table/drop.py
@@ -33,17 +33,21 @@ def _get_adjacent_partition_name(table, partitions_selected):
     """
     all_partition_names = table._partition_data.keys()
 
-    partition_before_first = _table_utils.get_previous_item(item=partitions_selected[0],
-                                                            sequence=all_partition_names)
-    partition_after_last = _table_utils.get_next_item(item=partitions_selected[-1],
-                                                      sequence=all_partition_names)
+    partition_before_first = _table_utils.get_previous_item(
+        item=partitions_selected[0], sequence=all_partition_names
+    )
+    partition_after_last = _table_utils.get_next_item(
+        item=partitions_selected[-1], sequence=all_partition_names
+    )
 
     if partition_before_first:
-        partition_names = _insert_adjacent_partition(partition_before_first,
-                                                     to=partitions_selected)
+        partition_names = _insert_adjacent_partition(
+            partition_before_first, to=partitions_selected
+        )
     elif partition_after_last:
-        partition_names = _insert_adjacent_partition(partition_after_last,
-                                                     to=partitions_selected)
+        partition_names = _insert_adjacent_partition(
+            partition_after_last, to=partitions_selected
+        )
     else:
         partition_names = partitions_selected
 
@@ -83,12 +87,14 @@ def has_still_default_index(table, rows):
         return False
 
     metadata = table._partition_data
-    if rows.keyword == 'before':
+    if rows.keyword == "before":
         is_still_default = _idx_still_default_after_dropping_rows_before(rows, metadata)
-    elif rows.keyword == 'after':
+    elif rows.keyword == "after":
         is_still_default = True
-    elif rows.keyword == 'between':
-        is_still_default = _idx_still_default_after_dropping_rows_between(rows, metadata)
+    elif rows.keyword == "between":
+        is_still_default = _idx_still_default_after_dropping_rows_between(
+            rows, metadata
+        )
     elif rows:
         is_still_default = _idx_still_default_after_dropping_rows_list(rows, metadata)
     else:
@@ -155,7 +161,6 @@ def can_drop_cols_from_table(table, cols):
 
 
 class CheckDropCols:
-
     def __init__(self, cols, table):
         self._table_path = table._table_path
         self._table_data = table._table_data
@@ -185,8 +190,9 @@ class CheckDropCols:
     def all_rows_are_dropped(self):
         trying_to_drop_all_cols = not bool(self._stored_cols - self._dropped_cols)
         if trying_to_drop_all_cols:
-            raise IndexError("Can't drop all columns. To drop full table, "
-                             "use 'drop_table()'")
+            raise IndexError(
+                "Can't drop all columns. To drop full table, use 'drop_table()'"
+            )
 
     def items_not_str(self):
         _raise_if.cols_argument_items_is_not_str_or_none(self._cols.values())
@@ -198,7 +204,7 @@ def drop_cols_from_data(df, cols):
 
 def create_partitions(df, rows_per_partition, partition_names):
     partitions = _table_utils.make_partitions(df, rows_per_partition)
-    partition_names = partition_names[:len(partitions)]
+    partition_names = partition_names[: len(partitions)]
     partitions = _table_utils.assign_ids_to_partitions(partitions, partition_names)
     return partitions
 
@@ -215,7 +221,7 @@ def drop_partitions(table, partitions):
 
 
 def _delete_partition(table, partition):
-    partition_path = os.path.join(table._table_path, f'{partition}.feather')
+    partition_path = os.path.join(table._table_path, f"{partition}.feather")
     _utils._remove_path(partition_path)
 
 

--- a/featherstore/_table/insert_cols.py
+++ b/featherstore/_table/insert_cols.py
@@ -44,8 +44,10 @@ def _raise_if_num_rows_does_not_match(df, table_data):
     new_cols_length = len(df)
 
     if new_cols_length != stored_table_length:
-        raise IndexError(f"Length of new cols ({new_cols_length}) doesn't match "
-                         f"length of stored data ({stored_table_length})")
+        raise IndexError(
+            f"Length of new cols ({new_cols_length}) doesn't match "
+            f"length of stored data ({stored_table_length})"
+        )
 
 
 def _raise_if_idx_is_invalid(df, idx):
@@ -53,12 +55,15 @@ def _raise_if_idx_is_invalid(df, idx):
 
     if _table_utils.is_collection(idx):
         if len(idx) != num_new_cols:
-            raise ValueError(f"Length of 'idx' ({len(idx)}) != number of new columns "
-                             f"({num_new_cols})")
+            raise ValueError(
+                f"Length of 'idx' ({len(idx)}) != number of new columns "
+                f"({num_new_cols})"
+            )
         for position in idx:
             if not isinstance(position, Integral):
-                raise TypeError(f"Elements in 'idx' must be of type int "
-                                f"(is type {type(position)})")
+                raise TypeError(
+                    f"Elements in 'idx' must be of type int (is type {type(position)})"
+                )
     elif not isinstance(idx, Integral):
         raise TypeError(f"'idx' must be an int (is type {type(idx)})")
 
@@ -110,9 +115,10 @@ def _insert_cols(old_df, df, index):
     return df
 
 
-
 def create_partitions(df, rows_per_partition, partition_names):
     partitions = _table_utils.make_partitions(df, rows_per_partition)
-    new_partition_names = _table_utils.add_new_partition_ids(partitions, partition_names)
+    new_partition_names = _table_utils.add_new_partition_ids(
+        partitions, partition_names
+    )
     partitions = _table_utils.assign_ids_to_partitions(partitions, new_partition_names)
     return partitions

--- a/featherstore/_table/insert_rows.py
+++ b/featherstore/_table/insert_rows.py
@@ -33,7 +33,6 @@ def insert_data(df, *, to):
     return df
 
 
-
 def _raise_if_rows_in_old_data(old_df, df, index_name):
     index = df[index_name]
     old_index = old_df[index_name]
@@ -46,8 +45,9 @@ def _raise_if_rows_in_old_data(old_df, df, index_name):
 
 def create_partitions(df, rows_per_partition, partition_names, all_partition_names):
     partitions = _table_utils.make_partitions(df, rows_per_partition)
-    new_partition_names = _insert_new_partition_ids(partitions, partition_names,
-                                                    all_partition_names)
+    new_partition_names = _insert_new_partition_ids(
+        partitions, partition_names, all_partition_names
+    )
     partitions = _table_utils.assign_ids_to_partitions(partitions, new_partition_names)
     return partitions
 
@@ -56,11 +56,12 @@ def _insert_new_partition_ids(partitioned_df, partition_names, all_partition_nam
     num_partitions = len(partitioned_df)
     num_partition_names = len(partition_names)
     num_names_to_make = num_partitions - num_partition_names
-    subsequent_partition = _table_utils.get_next_item(item=partition_names[-1],
-                                                      sequence=all_partition_names)
-    new_partition_names = _make_partition_names(num_names_to_make,
-                                                partition_names,
-                                                subsequent_partition)
+    subsequent_partition = _table_utils.get_next_item(
+        item=partition_names[-1], sequence=all_partition_names
+    )
+    new_partition_names = _make_partition_names(
+        num_names_to_make, partition_names, subsequent_partition
+    )
     return new_partition_names
 
 
@@ -92,7 +93,9 @@ def has_still_default_index(table, df):
     last_stored_value = _table_utils.get_last_stored_index_value(table._partition_data)
     first_row_value = rows[0].as_py()
 
-    rows_are_continuous = all(a.as_py() + 1 == b.as_py() for a, b in zip(rows, rows[1:]))
+    rows_are_continuous = all(
+        a.as_py() + 1 == b.as_py() for a, b in zip(rows, rows[1:])
+    )
     if first_row_value > last_stored_value and rows_are_continuous:
         _has_still_default_index = True
     elif len(rows) == 0:

--- a/featherstore/_table/read.py
+++ b/featherstore/_table/read.py
@@ -66,7 +66,7 @@ def _predicate_filtering(rows, partition_names, partition_data):
         start = _binary_search(min(rows.values()), partition_names, partition_data)
         end = _binary_search(max(rows.values()), partition_names, partition_data)
 
-    partition_names = partition_names[start:end + 1]
+    partition_names = partition_names[start : end + 1]
     return partition_names
 
 
@@ -91,21 +91,22 @@ def _binary_search(target, partition_names, partition_data):
 
 
 def _row_inside_candidate(target, candidate):
-    candidate_min = candidate['min']
-    candidate_max = candidate['max']
+    candidate_min = candidate["min"]
+    candidate_max = candidate["max"]
     return target <= candidate_max and target >= candidate_min
 
 
 def _row_before_candidate(target, candidate):
-    return target >= candidate['max']
+    return target >= candidate["max"]
 
 
 def _row_after_candidate(target, candidate):
-    return target <= candidate['min']
+    return target <= candidate["min"]
 
 
-def read_table(table, partition_names, cols=ColIndexer(None),
-               rows=RowIndexer(None), mmap=None):
+def read_table(
+    table, partition_names, cols=ColIndexer(None), rows=RowIndexer(None), mmap=None
+):
     index_name = table._table_data["index_name"]
     if cols.values() is None:
         cols = ColIndexer(table._table_data["columns"])
@@ -141,9 +142,9 @@ def __read_feather(path, cols, mmap):
 
 def _read_ipc_table(path, use_mmap):
     if use_mmap:
-        source = pa.memory_map(path, 'r')
+        source = pa.memory_map(path, "r")
     else:
-        source = pa.OSFile(path, 'r')
+        source = pa.OSFile(path, "r")
     try:
         return ipc.open_file(source).read_all()
     finally:
@@ -175,7 +176,7 @@ def convert_table_to_pandas(df):
 
     if _can_be_converted_to_series(df):
         df = df.squeeze(axis=1)
-        if df.name == '0':
+        if df.name == "0":
             df.name = None
 
     index = df.index
@@ -210,6 +211,6 @@ def convert_table_to_polars(df):
     if num_cols == 1:
         full_table = full_table.to_series()
         series_name = full_table.name
-        if series_name == '0':
-            full_table = pl.Series('', full_table)
+        if series_name == "0":
+            full_table = pl.Series("", full_table)
     return full_table

--- a/featherstore/_table/rename_cols.py
+++ b/featherstore/_table/rename_cols.py
@@ -33,7 +33,7 @@ def _raise_if_new_cols_items_is_not_str(new_cols):
 
 
 def _raise_if_renaming_causes_duplicates(cols, table_data):
-    stored_cols = table_data['columns']
+    stored_cols = table_data["columns"]
     renamed_cols = _replace_col_names(stored_cols, cols)
     _raise_if.col_names_contains_duplicates(renamed_cols)
 
@@ -56,4 +56,4 @@ def _replace_col_names(stored_cols, cols):
 def write_metadata(table, df):
     first_partition = tuple(df.values())[0]
     col_names = first_partition.schema.names
-    table._table_data['columns'] = col_names
+    table._table_data["columns"] = col_names

--- a/featherstore/_table/write.py
+++ b/featherstore/_table/write.py
@@ -19,18 +19,18 @@ def can_write_table(table, df, index_name, partition_size, errors, warnings):
     _utils.raise_if_warnings_argument_is_not_valid(warnings)
     _raise_if_partition_size_is_not_int(partition_size)
 
-    if errors == 'raise':
+    if errors == "raise":
         _raise_if.table_already_exists(table._table_path)
     _raise_if.df_is_not_supported_table_type(df)
 
     cols = _table_utils.get_col_names(df, has_default_index=False)
-    _raise_if_index_argument_is_not_str_or_None(index_name)
+    _raise_if_index_argument_is_not_str_or_none(index_name)
     _raise_if_provided_index_not_in_cols(index_name, cols)
     _raise_if.cols_argument_items_is_not_str_or_none(cols)
     _raise_if.col_names_contains_duplicates(cols)
 
     index = _table_utils.get_index_if_exists(df, index_name)
-    _raise_if_index_is_not_supported_type(index)
+    _raise_if.index_type_not_supported(index)
     _raise_if.index_values_contains_duplicates(index)
 
 
@@ -40,28 +40,15 @@ def _raise_if_partition_size_is_not_int(partition_size):
         raise TypeError(f"'partition_size' must be a int or (is type {dtype})")
 
 
-def _raise_if_index_argument_is_not_str_or_None(index):
+def _raise_if_index_argument_is_not_str_or_none(index):
     is_str_or_none = isinstance(index, str) or index is None
     if not is_str_or_none:
-        raise TypeError(
-            f"'index' must be a str or None (is type {type(index)})")
+        raise TypeError(f"'index' must be a str or None (is type {type(index)})")
 
 
 def _raise_if_provided_index_not_in_cols(index, cols):
     if isinstance(index, str) and index not in cols:
         raise IndexError("'index' not in table columns")
-
-
-def _raise_if_index_is_not_supported_type(index):
-    if index is not None:
-        index_type = str(index.type)
-        is_string = _table_utils.typestring_is_string(index_type)
-        is_temporal = _table_utils.typestring_is_temporal(index_type)
-        is_int = _table_utils.typestring_is_int(index_type)
-
-        if not (is_string or is_temporal or is_int):
-            raise TypeError(f"Table.index type must be either int, str or datetime "
-                            f"(is type {index_type})")
 
 
 def create_partitions(df, rows_per_partition, partition_names=None):
@@ -157,7 +144,7 @@ def _write_feather(df, file_path):
     # Feather V2 is the Arrow IPC file format. Write to a temp file first so we
     # never truncate an inode that may still be memory-mapped from a prior read.
     tmp_path = f"{file_path}.tmp"
-    with pa.OSFile(tmp_path, 'wb') as sink:
+    with pa.OSFile(tmp_path, "wb") as sink:
         with ipc.new_file(sink, df.schema) as writer:
             writer.write_table(df)
     os.replace(tmp_path, file_path)

--- a/featherstore/_utils.py
+++ b/featherstore/_utils.py
@@ -12,7 +12,7 @@ _WINDOWS_DELETE_RETRIES = 10
 _WINDOWS_DELETE_BACKOFF_S = 0.001
 
 
-def touch(path, flag='ab'):
+def touch(path, flag="ab"):
     with open(path, flag):
         pass
 
@@ -65,7 +65,7 @@ def rmtree(path):
         _remove_path(path)
     else:
         for sub_path in os.listdir(path):
-            sub_path = f'{path}/{sub_path}'
+            sub_path = f"{path}/{sub_path}"
             rmtree(sub_path)
         os.rmdir(path)
 

--- a/featherstore/snapshot.py
+++ b/featherstore/snapshot.py
@@ -4,10 +4,10 @@ import pickle
 from datetime import datetime
 from featherstore.connection import Connection, current_db
 
-METADATA_FILE_NAME = 'metadata.pkl'
+METADATA_FILE_NAME = "metadata.pkl"
 
 
-def restore_table(store_name, source, errors='raise'):
+def restore_table(store_name, source, errors="raise"):
     """Restores a table in to the currently selected db.
 
     Parameters
@@ -32,7 +32,7 @@ def restore_table(store_name, source, errors='raise'):
     return table_name
 
 
-def restore_store(source, errors='raise'):
+def restore_store(source, errors="raise"):
     """Restores a store in to the currently selected db.
 
     Parameters
@@ -55,8 +55,8 @@ def restore_store(source, errors='raise'):
 
 
 def _extract_snapshot(output_path, source):
-    if '.tar.xz' not in source:
-        source = f'{source}.tar.xz'
+    if ".tar.xz" not in source:
+        source = f"{source}.tar.xz"
     with tarfile.open(source, "r") as tar:
         members = tar.getnames()
         members.remove(METADATA_FILE_NAME)
@@ -68,7 +68,7 @@ def _extract_snapshot(output_path, source):
 
 def _extract_tar_member(tar, member, output_path):
     try:
-        tar.extract(member, output_path, filter='data')
+        tar.extract(member, output_path, filter="data")
     except TypeError:
         tar.extract(member, output_path)
 
@@ -108,29 +108,29 @@ def __raise_if_source_path_is_not_str(source):
 
 
 def __raise_if_snapshot_not_found(source):
-    if '.tar.xz' not in source:
-        source = f'{source}.tar.xz'
+    if ".tar.xz" not in source:
+        source = f"{source}.tar.xz"
     if not os.path.exists(source):
         raise FileNotFoundError("Snapshot not found")
 
 
 def __raise_if_not_snapshot_of_table(source):
-    if '.tar.xz' not in source:
-        source = f'{source}.tar.xz'
+    if ".tar.xz" not in source:
+        source = f"{source}.tar.xz"
 
     with tarfile.open(source, "r") as tar:
         metadata = tar.extractfile(METADATA_FILE_NAME).read()
         metadata = pickle.loads(metadata)
-    if metadata['type'] != 'table':
+    if metadata["type"] != "table":
         raise ValueError("File is not a snapshot of a table")
 
 
 def __raise_if_table_already_exists(store, source, errors):
-    if errors == 'raise':
+    if errors == "raise":
         store_path = os.path.join(current_db(), store)
 
-        if '.tar.xz' not in source:
-            source = f'{source}.tar.xz'
+        if ".tar.xz" not in source:
+            source = f"{source}.tar.xz"
         table_name = __get_name(source)
 
         if table_name in os.listdir(store_path):
@@ -138,22 +138,22 @@ def __raise_if_table_already_exists(store, source, errors):
 
 
 def __raise_if_store_already_exists(source, errors):
-    if '.tar.xz' not in source:
-        source = f'{source}.tar.xz'
+    if ".tar.xz" not in source:
+        source = f"{source}.tar.xz"
     store_name = __get_name(source)
 
-    if store_name in os.listdir(current_db()) and errors == 'raise':
+    if store_name in os.listdir(current_db()) and errors == "raise":
         raise FileExistsError(f"A store with name {store_name} already exists")
 
 
 def __raise_if_not_snapshot_of_store(source):
-    if '.tar.xz' not in source:
-        source = f'{source}.tar.xz'
+    if ".tar.xz" not in source:
+        source = f"{source}.tar.xz"
 
     with tarfile.open(source, "r") as tar:
         metadata = tar.extractfile(METADATA_FILE_NAME).read()
         metadata = pickle.loads(metadata)
-    if metadata['type'] != 'store':
+    if metadata["type"] != "store":
         raise ValueError("File is not a snapshot of a store")
 
 
@@ -161,6 +161,7 @@ def __get_name(source):
     with tarfile.open(source, "r") as tar:
         name = tar.getnames()[0]
     return name
+
 
 # ----------------- create snapshot ------------------
 
@@ -188,21 +189,20 @@ def __raise_if_input_doesnt_exists(input_path):
 
 
 def __raise_if_input_type_is_not_valid(input_type):
-    if input_type not in ('table', 'store'):
+    if input_type not in ("table", "store"):
         raise ValueError("Input type should be either 'table' or 'store")
 
 
 def __create_snapshot_metadata(metadata_path, source_type):
-    snapshot_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    metadata = {'type': source_type,
-                'snapshot_time': snapshot_time}
-    with open(metadata_path, 'wb') as f:
+    snapshot_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    metadata = {"type": source_type, "snapshot_time": snapshot_time}
+    with open(metadata_path, "wb") as f:
         f.write(pickle.dumps(metadata))
 
 
 def __write_snapshot(output_path, input_path, metadata_path):
-    if 'tar.xz' not in output_path:
-        output_path = f'{output_path}.tar.xz'
+    if "tar.xz" not in output_path:
+        output_path = f"{output_path}.tar.xz"
 
     with tarfile.open(output_path, "w:xz") as tar:
         tar.add(input_path, arcname=os.path.basename(input_path))

--- a/featherstore/store.py
+++ b/featherstore/store.py
@@ -351,13 +351,13 @@ class Store:
         path : str
             The path to the snapshot archive.
         """
-        _create_snapshot(path, self._store_path, 'store')
+        _create_snapshot(path, self._store_path, "store")
 
 
 def _can_create_store(store_name, errors):
     Connection._raise_if_not_connected()
     _utils.raise_if_errors_argument_is_not_valid(errors)
-    if errors == 'raise':
+    if errors == "raise":
         _raise_if_store_already_exists(store_name)
     _raise_if_store_name_is_forbidden(store_name)
 
@@ -423,5 +423,4 @@ def _can_list(like):
 
 def _raise_if_like_is_not_str(like):
     if not isinstance(like, (str, type(None))):
-        raise TypeError(
-            f"'like' must be either of type str or None, is {type(like)}")
+        raise TypeError(f"'like' must be either of type str or None, is {type(like)}")

--- a/featherstore/table.py
+++ b/featherstore/table.py
@@ -82,7 +82,9 @@ class Table:
         partition_names = read.get_partition_names(self, rows)
         df = read.read_table(self, partition_names, cols, rows, mmap=mmap)
 
-        if has_default_index and (rows.values() is None or common.index_is_default(df[index_name])):
+        if has_default_index and (
+            rows.values() is None or common.index_is_default(df[index_name])
+        ):
             df = read.drop_default_index(df, index_name)
 
         return df
@@ -135,9 +137,16 @@ class Table:
         df = read.convert_table_to_polars(df)
         return df
 
-    def write(self, df, /, index=None, *,
-              partition_size=DEFAULT_PARTITION_SIZE,
-              errors="raise", warnings="warn"):
+    def write(
+        self,
+        df,
+        /,
+        index=None,
+        *,
+        partition_size=DEFAULT_PARTITION_SIZE,
+        errors="raise",
+        warnings="warn",
+    ):
         """Writes a DataFrame to the current table.
 
         The DataFrame index column, if provided, must be either of type int, str,
@@ -167,8 +176,9 @@ class Table:
         rows_per_partition = common.compute_rows_per_partition(df, partition_size)
 
         partitions = write.create_partitions(df, rows_per_partition)
-        metadata = write.generate_metadata(partitions, partition_size,
-                                           rows_per_partition)
+        metadata = write.generate_metadata(
+            partitions, partition_size, rows_per_partition
+        )
         self.drop_table()
         self._create_table()
         write.write_metadata(self, metadata)
@@ -201,11 +211,13 @@ class Table:
         last_partition = read.read_table(self, [last_partition_name])
 
         df = append.append_data(df, to=last_partition)
-        partitions = append.create_partitions(df, rows_per_partition,
-                                              last_partition_name)
+        partitions = append.create_partitions(
+            df, rows_per_partition, last_partition_name
+        )
 
-        metadata = common.update_metadata(self, partitions, [last_partition_name],
-                                          has_default_index=has_default_index)
+        metadata = common.update_metadata(
+            self, partitions, [last_partition_name], has_default_index=has_default_index
+        )
 
         write.write_metadata(self, metadata)
         write.write_partitions(partitions, self._table_path)
@@ -278,19 +290,20 @@ class Table:
 
         rows = common.format_rows_arg(df.index, to_dtype=index_type)
 
-        df = common.format_table(df, index_name=index_name, warnings='ignore')
+        df = common.format_table(df, index_name=index_name, warnings="ignore")
         has_default_index = insert_rows.has_still_default_index(self, df)
 
         partition_names = read.get_partition_names(self, rows)
         stored_df = read.read_table(self, partition_names)
 
         df = insert_rows.insert_data(df, to=stored_df)
-        partitions = insert_rows.create_partitions(df, rows_per_partition,
-                                                   partition_names,
-                                                   all_partition_names)
+        partitions = insert_rows.create_partitions(
+            df, rows_per_partition, partition_names, all_partition_names
+        )
 
-        metadata = common.update_metadata(self, partitions, partition_names,
-                                          has_default_index=has_default_index)
+        metadata = common.update_metadata(
+            self, partitions, partition_names, has_default_index=has_default_index
+        )
 
         write.write_metadata(self, metadata)
         write.write_partitions(partitions, self._table_path)
@@ -320,12 +333,17 @@ class Table:
 
         rows_per_partition = common.compute_rows_per_partition(df, partition_size)
         columns = df.column_names
-        partitions = insert_cols.create_partitions(df, rows_per_partition,
-                                                   partition_names)
+        partitions = insert_cols.create_partitions(
+            df, rows_per_partition, partition_names
+        )
 
-        metadata = common.update_metadata(self, partitions, partition_names,
-                                          rows_per_partition=rows_per_partition,
-                                          columns=columns)
+        metadata = common.update_metadata(
+            self,
+            partitions,
+            partition_names,
+            rows_per_partition=rows_per_partition,
+            columns=columns,
+        )
 
         write.write_metadata(self, metadata)
         write.write_partitions(partitions, self._table_path)
@@ -384,8 +402,9 @@ class Table:
         partitions = drop.create_partitions(df, rows_per_partition, partition_names)
 
         has_default_index = drop.has_still_default_index(self, rows)
-        metadata = common.update_metadata(self, partitions, partition_names,
-                                          has_default_index=has_default_index)
+        metadata = common.update_metadata(
+            self, partitions, partition_names, has_default_index=has_default_index
+        )
 
         partitions_to_drop = drop.get_partitions_to_drop(partitions, partition_names)
         drop.drop_partitions(self, partitions_to_drop)
@@ -424,9 +443,13 @@ class Table:
         partitions = drop.create_partitions(df, rows_per_partition, partition_names)
 
         columns = df.column_names
-        metadata = common.update_metadata(self, partitions, partition_names,
-                                          rows_per_partition=rows_per_partition,
-                                          columns=columns)
+        metadata = common.update_metadata(
+            self,
+            partitions,
+            partition_names,
+            rows_per_partition=rows_per_partition,
+            columns=columns,
+        )
 
         partitions_to_drop = drop.get_partitions_to_drop(partitions, partition_names)
         drop.drop_partitions(self, partitions_to_drop)
@@ -547,8 +570,9 @@ class Table:
         rows_per_partition = common.compute_rows_per_partition(df, partition_size)
         partitions = astype.create_partitions(df, rows_per_partition, partition_names)
 
-        metadata = common.update_metadata(self, partitions, partition_names,
-                                          rows_per_partition=rows_per_partition)
+        metadata = common.update_metadata(
+            self, partitions, partition_names, rows_per_partition=rows_per_partition
+        )
 
         partitions_to_drop = astype.get_partitions_to_drop(partitions, partition_names)
         drop.drop_partitions(self, partitions_to_drop)
@@ -590,7 +614,7 @@ class Table:
         path : str
             The path to the snapshot archive.
         """
-        _create_snapshot(path, self._table_path, 'table')
+        _create_snapshot(path, self._table_path, "table")
 
     def repartition(self, new_partition_size):
         """Repartitions a table so that each partition is `new_partition_size` big.
@@ -607,8 +631,9 @@ class Table:
             index_name = None
         else:
             index_name = self._table_data["index_name"]
-        self.write(df, index=index_name, partition_size=new_partition_size,
-                   errors='ignore')
+        self.write(
+            df, index=index_name, partition_size=new_partition_size, errors="ignore"
+        )
 
     @property
     def shape(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas>=2.2.0",
-    "polars[timezone]>=1.0.0",
+    "polars[timezone]>=1.21.0",
     "pyarrow>=14.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ markers = [
 
 [tool.flake8]
 exclude = [".dev", "benchmarks", "build", "dist"]
-ignore = ["F405", "F403"]
+ignore = ["F405", "F403", "E203"]
 max-line-length = 100
 count = true
 per-file-ignores = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ class SetupDB:
             store = fs.Store(store_name)
             for table in store.list_tables():
                 store.drop_table(table)
-            fs.drop_store(store_name, errors='ignore')
+            fs.drop_store(store_name, errors="ignore")
         fs.disconnect()
         shutil.rmtree(DB_PATH, ignore_errors=False)
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+import featherstore as fs
+
+from .fixtures import (
+    DB_PATH,
+    STORE_NAME,
+    TABLE_NAME,
+    apply_operations_to_expected,
+    assert_store_table_equal,
+    build_e2e_operations,
+    get_partition_size,
+    make_hardcoded_table,
+    shuffle_e2e_operations,
+)
+
+SNAPSHOT_PATH = os.path.join(DB_PATH, "e2e_table_snapshot.tar.xz")
+RESTORE_STORE_NAME = f"{STORE_NAME}_restored"
+
+
+@pytest.mark.e2e
+def test_full_table_workflow(store):
+    # Arrange
+    df = make_hardcoded_table()
+    operations = shuffle_e2e_operations(build_e2e_operations(), seed=0)
+    expected = apply_operations_to_expected(df, operations)
+
+    partition_size = get_partition_size(df)
+    table = store.select_table(TABLE_NAME)
+    table.write(df, partition_size=partition_size, warnings="ignore")
+
+    # Act
+    for operation in operations:
+        operation.apply_to_table(table)
+
+    table.create_snapshot(SNAPSHOT_PATH)
+    fs.create_store(RESTORE_STORE_NAME)
+    fs.snapshot.restore_table(RESTORE_STORE_NAME, SNAPSHOT_PATH)
+
+    # Assert
+    assert_store_table_equal(RESTORE_STORE_NAME, TABLE_NAME, expected)
+
+    # Teardown
+    os.remove(SNAPSHOT_PATH)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,7 +1,9 @@
 from os.path import join
 from featherstore._utils import DEFAULT_ARROW_INDEX_NAME, DB_MARKER_NAME
 
+from .cast_table import change_dtype, to_arrow_dtype
 from .convert_table import convert_table
+from .expected_table import merge_rows, insert_columns_expected, insert_column_names_at
 from .make_table import (
     make_table,
     default_index,
@@ -13,6 +15,14 @@ from .make_table import (
     unsorted_int_index,
     unsorted_string_index,
     unsorted_datetime_index,
+    sorted_timedelta_index,
+    sorted_time32_index,
+    sorted_date32_index,
+    sorted_float_index,
+    sorted_uint_index,
+    sorted_decimal_index,
+    sorted_binary_index,
+    sorted_large_string_index,
 )
 from .misc import (
     shuffle_cols,
@@ -25,10 +35,66 @@ from .misc import (
 from .split_table import split_table
 from ._utils import get_index_name
 from .update_values import update_values
-from .assertions import assert_table_equals, assert_df_equals
+from .assertions import assert_table_equals, assert_df_equals, assert_store_table_equal
+from .hardcoded_table import (
+    make_hardcoded_table,
+    build_e2e_operations,
+    shuffle_e2e_operations,
+    apply_operations_to_expected,
+)
 
-DB_PATH = join('tests', '_db')
+DB_PATH = join("tests", "_db")
 STORE_NAME = "test_store"
 TABLE_NAME = "table_name"
 TABLE_PATH = join(DB_PATH, STORE_NAME, TABLE_NAME)
-MD_NAME = 'db'
+MD_NAME = "db"
+
+__all__ = [
+    "DEFAULT_ARROW_INDEX_NAME",
+    "DB_MARKER_NAME",
+    "change_dtype",
+    "to_arrow_dtype",
+    "convert_table",
+    "merge_rows",
+    "insert_columns_expected",
+    "insert_column_names_at",
+    "make_table",
+    "default_index",
+    "fake_default_index",
+    "sorted_string_index",
+    "sorted_datetime_index",
+    "continuous_datetime_index",
+    "continuous_string_index",
+    "unsorted_int_index",
+    "unsorted_string_index",
+    "unsorted_datetime_index",
+    "sorted_timedelta_index",
+    "sorted_time32_index",
+    "sorted_date32_index",
+    "sorted_float_index",
+    "sorted_uint_index",
+    "sorted_decimal_index",
+    "sorted_binary_index",
+    "sorted_large_string_index",
+    "shuffle_cols",
+    "sort_table",
+    "get_partition_size",
+    "format_arrow_table",
+    "df_has_default_index",
+    "drop_default_index_if_exists",
+    "split_table",
+    "get_index_name",
+    "update_values",
+    "assert_table_equals",
+    "assert_df_equals",
+    "assert_store_table_equal",
+    "make_hardcoded_table",
+    "build_e2e_operations",
+    "shuffle_e2e_operations",
+    "apply_operations_to_expected",
+    "DB_PATH",
+    "STORE_NAME",
+    "TABLE_NAME",
+    "TABLE_PATH",
+    "MD_NAME",
+]

--- a/tests/fixtures/_utils.py
+++ b/tests/fixtures/_utils.py
@@ -31,12 +31,12 @@ def get_index_name(df):
         index_name = None
     else:
         cols = get_col_names(df)
-        if 'Date' in cols:
-            index_name = 'Date'
-        elif 'index' in cols:
-            index_name = 'index'
-        elif 'Index' in cols:
-            index_name = 'index'
+        if "Date" in cols:
+            index_name = "Date"
+        elif "index" in cols:
+            index_name = "index"
+        elif "Index" in cols:
+            index_name = "index"
         elif DEFAULT_ARROW_INDEX_NAME in cols:
             index_name = DEFAULT_ARROW_INDEX_NAME
         else:
@@ -65,6 +65,6 @@ def convert_object_cols_to_string(df):
     else:
         dtypes = df.dtypes
     for col, dtype in dtypes.items():
-        if dtype in ('O', 'U'):
+        if dtype in ("O", "U"):
             df[col] = pd.array(df[col], dtype="string")
     return df

--- a/tests/fixtures/assertions.py
+++ b/tests/fixtures/assertions.py
@@ -3,15 +3,23 @@ import polars as pl
 import pyarrow as pa
 from pandas.testing import assert_frame_equal, assert_series_equal
 
+import featherstore as fs
+
 from .convert_table import convert_table
+
+
+def assert_store_table_equal(store_name, table_name, expected, **kwargs):
+    store = fs.Store(store_name)
+    table = store.select_table(table_name)
+    assert_table_equals(table, expected, **kwargs)
 
 
 def assert_table_equals(table, expected, *, rows=None, cols=None, astype=None):
     if not astype:
         astype = _get_astype(expected)
 
-    if astype == 'all':
-        for astype in ('arrow', 'polars', 'pandas'):
+    if astype == "all":
+        for astype in ("arrow", "polars", "pandas"):
             expected_ = convert_table(expected, to=astype)
             assert_table_equals(table, expected_, rows=rows, cols=cols, astype=astype)
     else:
@@ -31,9 +39,9 @@ def _get_astype(df):
 def _read_df(table, astype, rows, cols):
     if astype == "arrow":
         df = table.read_arrow(rows=rows, cols=cols)
-    elif astype == 'polars':
+    elif astype == "polars":
         df = table.read_polars(rows=rows, cols=cols)
-    elif astype.startswith('pandas'):
+    elif astype.startswith("pandas"):
         df = table.read_pandas(rows=rows, cols=cols)
     return df
 
@@ -44,9 +52,9 @@ def assert_df_equals(df, expected, astype=None):
 
     if astype == "arrow":
         assert df.equals(expected)
-    elif astype.startswith('polars'):
+    elif astype.startswith("polars"):
         _assert_polars(df, expected)
-    elif astype.startswith('pandas'):
+    elif astype.startswith("pandas"):
         _assert_pandas(df, expected)
 
 

--- a/tests/fixtures/cast_table.py
+++ b/tests/fixtures/cast_table.py
@@ -1,0 +1,35 @@
+import pyarrow as pa
+
+
+def change_dtype(df, to, index_name="index", cols=None):
+    target_dtype = to_arrow_dtype(to)
+    cols_to_cast = cols if cols is not None else df.schema.names
+
+    schema = _replace_column_dtypes(df.schema, target_dtype, cols_to_cast, index_name)
+    df = df.cast(schema)
+    return _drop_pandas_metadata(df)
+
+
+def _replace_column_dtypes(schema, dtype, cols, index_name):
+    for idx, field in enumerate(schema):
+        if field.name not in cols or field.name == index_name:
+            continue
+        schema = schema.set(idx, field.with_type(dtype))
+    return schema
+
+
+def _drop_pandas_metadata(df):
+    """Casting does not refresh pandas metadata; drop it so conversions follow Arrow types."""
+    metadata = df.schema.metadata
+    if not metadata or b"pandas" not in metadata:
+        return df
+
+    metadata = {key: value for key, value in metadata.items() if key != b"pandas"}
+    return df.replace_schema_metadata(metadata or None)
+
+
+def to_arrow_dtype(dtype):
+    try:
+        return pa.from_numpy_dtype(dtype)
+    except Exception:
+        return dtype

--- a/tests/fixtures/convert_table.py
+++ b/tests/fixtures/convert_table.py
@@ -7,9 +7,9 @@ from . import _utils
 
 
 def convert_table(df, *, to, index_name=None, as_series=True):
-    if to == 'pandas':
+    if to == "pandas":
         df = _convert_to_pandas(df, index_name=index_name, as_series=as_series)
-    elif to == 'arrow':
+    elif to == "arrow":
         df = _convert_to_arrow(df)
     elif to == "polars":
         df = _convert_to_polars(df, as_series=as_series)
@@ -41,12 +41,12 @@ def _convert_to_pandas(df, index_name=None, as_series=True):
 
 def __convert_object_cols_to_string(df):
     for col in df.columns:
-        if df[col].dtype.name == 'object':
+        if df[col].dtype.name == "object":
             try:
                 if isinstance(df[col][0], str):
-                    df[col] = df[col].astype('string')
+                    df[col] = df[col].astype("string")
             except KeyError:
-                df[col] = df[col].astype('string')
+                df[col] = df[col].astype("string")
     return df
 
 

--- a/tests/fixtures/expected_table.py
+++ b/tests/fixtures/expected_table.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from .convert_table import convert_table
+from .misc import format_arrow_table, sort_table
+
+
+def merge_rows(df, other, *, as_arrow=False):
+    new_df = sort_table(pd.concat([df, other]))
+    if as_arrow:
+        new_df = convert_table(new_df, to="arrow")
+        new_df = format_arrow_table(new_df)
+    return new_df
+
+
+def insert_columns_expected(expected, new_cols, idx):
+    expected = expected.copy()
+    new_cols = new_cols.copy()
+    new_cols.index = expected.index
+    for offset, col_name in enumerate(new_cols.columns):
+        expected.insert(idx + offset, col_name, new_cols[col_name])
+    return expected
+
+
+def insert_column_names_at(df, col_names, insert_idx):
+    columns = df.columns.tolist()
+    start, end = _column_slice_for_insert(insert_idx, len(col_names))
+    columns[start:end] = col_names
+    df.columns = columns
+    return df
+
+
+def _column_slice_for_insert(insert_idx, num_cols):
+    end = insert_idx + num_cols
+    if insert_idx < 0:
+        insert_idx = -num_cols
+        end = None
+    return insert_idx, end

--- a/tests/fixtures/hardcoded_table.py
+++ b/tests/fixtures/hardcoded_table.py
@@ -1,0 +1,205 @@
+import random
+from dataclasses import dataclass
+
+import pandas as pd
+import pyarrow as pa
+
+from .cast_table import change_dtype
+from .convert_table import convert_table
+from .expected_table import insert_columns_expected, merge_rows
+from .make_table import make_table
+from .split_table import split_table
+
+E2E_SEED = 0
+ROW_LABELS = [f"r{i:02d}" for i in range(10)]
+INSERT_ROW_LABELS = ["r10", "r11"]
+INSERT_COL_NAMES = ["n0", "n1"]
+INSERT_COL_IDX = 2
+
+
+def _after_row_ops_table():
+    index = pd.Index(ROW_LABELS + INSERT_ROW_LABELS, name="row_id")
+    df = make_table(rows=12, cols=5, astype="pandas", seed=E2E_SEED, dtype="float")
+    df.index = index
+    return df
+
+
+def _after_insert_col_table():
+    insert_cols = make_table(
+        rows=12,
+        cols=len(INSERT_COL_NAMES),
+        astype="pandas",
+        seed=E2E_SEED + 1,
+        dtype="int",
+    )
+    insert_cols.columns = INSERT_COL_NAMES
+    return insert_columns_expected(_after_row_ops_table(), insert_cols, INSERT_COL_IDX)
+
+
+def make_hardcoded_table():
+    """Return the initial table written at the start of the e2e workflow."""
+    without_insert, _ = split_table(_after_row_ops_table(), rows=INSERT_ROW_LABELS)
+    initial, _ = split_table(without_insert, rows=ROW_LABELS[6:10])
+    return initial
+
+
+def make_hardcoded_append_df():
+    """Rows appended after the initial write."""
+    without_insert, _ = split_table(_after_row_ops_table(), rows=INSERT_ROW_LABELS)
+    _, append_df = split_table(without_insert, rows=ROW_LABELS[6:10])
+    return append_df
+
+
+def make_hardcoded_insert_rows_df():
+    """Rows inserted by index during the e2e workflow."""
+    _, insert_df = split_table(_after_row_ops_table(), rows=INSERT_ROW_LABELS)
+    return insert_df
+
+
+def make_hardcoded_insert_cols_df(num_rows):
+    _, insert_cols = split_table(_after_insert_col_table(), cols=INSERT_COL_NAMES)
+    return insert_cols.iloc[:num_rows]
+
+
+@dataclass(frozen=True)
+class E2EOperation:
+    name: str
+    group: int
+
+    def apply_to_table(self, table):
+        raise NotImplementedError
+
+    def apply_to_expected(self, expected):
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class AppendOperation(E2EOperation):
+    append_df: pd.DataFrame
+
+    def apply_to_table(self, table):
+        table.append(self.append_df, warnings="ignore")
+
+    def apply_to_expected(self, expected):
+        return merge_rows(expected, self.append_df)
+
+
+@dataclass(frozen=True)
+class InsertRowsOperation(E2EOperation):
+    insert_df: pd.DataFrame
+
+    def apply_to_table(self, table):
+        table.insert(self.insert_df)
+
+    def apply_to_expected(self, expected):
+        return merge_rows(expected, self.insert_df)
+
+
+@dataclass(frozen=True)
+class InsertColsOperation(E2EOperation):
+    col_idx: int = INSERT_COL_IDX
+
+    def apply_to_table(self, table):
+        stored_df = table.read_pandas()
+        insert_df = make_hardcoded_insert_cols_df(len(stored_df))
+        insert_df.index = stored_df.index
+        table.insert(insert_df, idx=self.col_idx)
+
+    def apply_to_expected(self, expected):
+        insert_df = make_hardcoded_insert_cols_df(len(expected))
+        return insert_columns_expected(expected, insert_df, self.col_idx)
+
+
+@dataclass(frozen=True)
+class DropOperation(E2EOperation):
+    rows: object = None
+    cols: object = None
+
+    def apply_to_table(self, table):
+        table.drop(rows=self.rows, cols=self.cols)
+
+    def apply_to_expected(self, expected):
+        expected, _ = split_table(expected, rows=self.rows, cols=self.cols)
+        return expected
+
+
+@dataclass(frozen=True)
+class RenameColumnsOperation(E2EOperation):
+    columns: object
+    to: object = None
+
+    def apply_to_table(self, table):
+        table.rename_columns(self.columns, to=self.to)
+
+    def apply_to_expected(self, expected):
+        if isinstance(self.columns, dict):
+            return expected.rename(columns=self.columns)
+        renamed = expected.copy()
+        renamed.columns = self.to if self.to is not None else self.columns
+        return renamed
+
+
+@dataclass(frozen=True)
+class ReorderColumnsOperation(E2EOperation):
+    columns: list
+
+    def apply_to_table(self, table):
+        table.reorder_columns(self.columns)
+
+    def apply_to_expected(self, expected):
+        return expected[self.columns]
+
+
+@dataclass(frozen=True)
+class AstypeOperation(E2EOperation):
+    columns: list
+    dtype: object
+
+    def apply_to_table(self, table):
+        table.astype(self.columns, to=[self.dtype] * len(self.columns))
+
+    def apply_to_expected(self, expected):
+        index_name = expected.index.name
+        arrow_df = convert_table(expected, to="arrow")
+        arrow_df = change_dtype(arrow_df, self.dtype, cols=self.columns)
+        return convert_table(arrow_df, to="pandas", index_name=index_name)
+
+
+def build_e2e_operations():
+    return [
+        AppendOperation("append", group=1, append_df=make_hardcoded_append_df()),
+        InsertRowsOperation(
+            "insert_row", group=1, insert_df=make_hardcoded_insert_rows_df()
+        ),
+        InsertColsOperation("insert_col", group=2),
+        DropOperation("drop_rows", group=3, rows=["r00", "r10"]),
+        DropOperation("drop_cols", group=3, cols=["c1"]),
+        RenameColumnsOperation(
+            "rename_columns",
+            group=4,
+            columns={"c0": "a0", "c3": "a3"},
+        ),
+        ReorderColumnsOperation(
+            "reorder_columns",
+            group=4,
+            columns=["a3", "n0", "a0", "n1", "c2", "c4"],
+        ),
+        AstypeOperation("astype", group=4, columns=["a0"], dtype=pa.float32()),
+    ]
+
+
+def shuffle_e2e_operations(operations, *, seed=0):
+    def by_group(group):
+        return [op for op in operations if op.group == group]
+
+    group_3 = by_group(3)
+    random.Random(seed).shuffle(group_3)
+
+    return by_group(1) + by_group(2) + group_3 + by_group(4)
+
+
+def apply_operations_to_expected(initial_df, operations):
+    expected = initial_df.copy()
+    for operation in operations:
+        expected = operation.apply_to_expected(expected)
+    return expected

--- a/tests/fixtures/make_table.py
+++ b/tests/fixtures/make_table.py
@@ -1,6 +1,8 @@
 import itertools
 from string import ascii_letters, ascii_lowercase
 
+from decimal import Decimal
+
 import pandas as pd
 import polars as pl
 import pyarrow as pa
@@ -9,11 +11,15 @@ import numpy as np
 from featherstore._utils import DEFAULT_ARROW_INDEX_NAME
 from . import _utils
 
-RANDS_CHARS = np.array(list(ascii_letters + ' '))
+RANDS_CHARS = np.array(list(ascii_letters + " "))
+TIME32_INDEX_NAME = "Time"
 
 
-def make_table(index=None, rows=30, cols=5, *, astype="arrow", dtype=None, **kwargs):
-    df = _make_df(rows, cols, dtype=dtype)
+def make_table(
+    index=None, rows=30, cols=5, *, astype="arrow", dtype=None, seed=None, **kwargs
+):
+    rng = np.random.default_rng(seed)
+    df = _make_df(rows, cols, dtype=dtype, rng=rng)
     df = pd.DataFrame.from_dict(df)
     df = _utils.convert_object_cols_to_string(df)
     if index == default_index:
@@ -24,7 +30,7 @@ def make_table(index=None, rows=30, cols=5, *, astype="arrow", dtype=None, **kwa
     return df
 
 
-def _make_df(rows, cols, dtype=None):
+def _make_df(rows, cols, dtype=None, rng=None):
     col_dtypes = get_col_dtypes()
 
     if dtype:
@@ -35,65 +41,80 @@ def _make_df(rows, cols, dtype=None):
     data = dict()
     for col in range(cols):
         col_dtype = next(col_dtypes)
-        data[f"c{col}"] = col_dtype(rows)
+        data[f"c{col}"] = col_dtype(rows, rng)
 
     return data
 
 
 def get_col_dtypes():
     COL_DTYPES = {
-        'string': _make_string_col,
-        'float': _make_float_col,
-        'int': _make_int_col,
-        'datetime': _make_datetime_col,
-        'bool': _make_bool_column,
-        'uint': _make_uint_col,
-        'categorical': _make_categorical_cols,
+        "string": _make_string_col,
+        "float": _make_float_col,
+        "int": _make_int_col,
+        "datetime": _make_datetime_col,
+        "bool": _make_bool_column,
+        "uint": _make_uint_col,
+        "categorical": _make_categorical_cols,
     }
     return COL_DTYPES
 
 
-def _make_float_col(rows):
-    return np.random.random(size=rows)
+def _make_float_col(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
+    return rng.random(size=rows)
 
 
-def _make_uint_col(rows):
-    return np.random.randint(0, 200000, size=rows)
+def _make_uint_col(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
+    return rng.integers(0, 200000, size=rows)
 
 
-def _make_int_col(rows):
-    return np.random.randint(-100000, 100000, size=rows)
+def _make_int_col(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
+    return rng.integers(-100000, 100000, size=rows)
 
 
-def _make_categorical_cols(rows):
-    return pd.cut(np.random.random(size=rows), (-np.inf, -0.5, 0.5, np.inf), labels=['low', 'med', 'high'])
+def _make_categorical_cols(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
+    return pd.cut(
+        rng.random(size=rows),
+        (-np.inf, -0.5, 0.5, np.inf),
+        labels=["low", "med", "high"],
+    )
 
 
-def _make_datetime_col(rows):
+def _make_datetime_col(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
     start = -852076800  # 1943-01-01 in seconds relative to epoch
     end = 1640995200  # 2022-01-01 in seconds relative to epoch
-    times_since_epoch = np.random.randint(start, end, size=rows, dtype=np.int32)
-    dtime = times_since_epoch.astype('datetime64[ns]')
+    times_since_epoch = rng.integers(start, end, size=rows, dtype=np.int32)
+    dtime = times_since_epoch.astype("datetime64[ns]")
     return dtime
 
 
-def _make_string_col(rows):
+def _make_string_col(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
     STR_LENGTH = 5
-    df = (np.random.choice(RANDS_CHARS, size=STR_LENGTH * rows)
-          .view((np.str_, STR_LENGTH)).reshape(rows))
+    df = (
+        rng.choice(RANDS_CHARS, size=STR_LENGTH * rows)
+        .view((np.str_, STR_LENGTH))
+        .reshape(rows)
+    )
     return df
 
 
-def _make_bool_column(rows):
-    return np.random.randint(0, 2, size=rows, dtype=bool)
+def _make_bool_column(rows, rng=None):
+    rng = np.random.default_rng() if rng is None else rng
+    return rng.integers(0, 2, size=rows, dtype=bool)
 
 
 def _convert_df_to(df, *, to):
     astype = to
-    if not astype.startswith('pandas'):
+    if not astype.startswith("pandas"):
         df = pa.Table.from_pandas(df)
         if not __is_default_index(df):
             df = _utils.make_index_first_column(df)
+        df = _cast_time32_index_if_needed(df)
     if astype.startswith("polars"):
         df = pl.from_arrow(df)
 
@@ -140,7 +161,7 @@ def sorted_string_index(rows):
 def sorted_datetime_index(rows):
     index = __make_unique_datetime_col(rows)
     index = pd.Index(index)
-    index.name = 'Date'
+    index.name = "Date"
     return index.sort_values()
 
 
@@ -148,7 +169,7 @@ def __make_unique_datetime_col(rows):
     start = -852076800  # 1943-01-01 in seconds relative to epoch
     end = 1640995200  # 2022-01-01 in seconds relative to epoch
     times_since_epoch = __random_unique_numbers(start, end, rows)
-    dtime = times_since_epoch.astype('datetime64[s]')
+    dtime = times_since_epoch.astype("datetime64[s]")
     return dtime
 
 
@@ -161,7 +182,7 @@ def __random_unique_numbers(start, end, rows):
 def continuous_datetime_index(rows):
     index = pd.date_range(start="2021-01-01", periods=rows, freq="D")
     index = pd.Index(index)
-    index.name = 'Date'
+    index.name = "Date"
     return index
 
 
@@ -200,5 +221,66 @@ def unsorted_string_index(rows):
 def unsorted_datetime_index(rows):
     index = __make_unique_datetime_col(rows)
     index = pd.Index(index)
-    index.name = 'Date'
+    index.name = "Date"
     return index
+
+
+def sorted_timedelta_index(rows):
+    index = pd.timedelta_range("1 day", periods=rows, freq="D")
+    index = pd.Index(index, name="Timedelta")
+    return index.sort_values()
+
+
+def sorted_time32_index(rows):
+    milliseconds = [(idx + 1) * 3_600_000 for idx in range(rows)]
+    index = pd.Index(
+        [pd.to_datetime(ms, unit="ms").time() for ms in milliseconds],
+        name=TIME32_INDEX_NAME,
+    )
+    return index.sort_values()
+
+
+def sorted_date32_index(rows):
+    index = pd.date_range("2021-01-01", periods=rows, freq="D").date
+    index = pd.Index(index, name="Date")
+    return index.sort_values()
+
+
+def sorted_float_index(rows):
+    index = pd.Index(np.arange(rows, dtype=float) + 0.5, name="Float")
+    return index.sort_values()
+
+
+def sorted_uint_index(rows):
+    index = pd.Index(np.arange(rows, dtype=np.uint32) + 100, name="UInt")
+    return index.sort_values()
+
+
+def sorted_decimal_index(rows):
+    index = pd.Index([Decimal(f"{idx + 1}.1") for idx in range(rows)], name="Decimal")
+    return index.sort_values()
+
+
+def sorted_binary_index(rows):
+    index = pd.Index(
+        [bytes(f"{idx:02d}", "ascii") for idx in range(rows)], name="Binary"
+    )
+    return index.sort_values()
+
+
+def sorted_large_string_index(rows):
+    index = pd.Index(
+        pd.array([f"idx_{idx:04d}" for idx in range(rows)], dtype="string"),
+        name="LargeString",
+    )
+    return index.sort_values()
+
+
+def _cast_time32_index_if_needed(df):
+    index_name = df.schema.pandas_metadata["index_columns"][0]
+    if index_name != TIME32_INDEX_NAME:
+        return df
+
+    col_idx = df.column_names.index(index_name)
+    index_col = df[index_name].cast(pa.time32("ms"))
+    return df.set_column(col_idx, index_name, index_col)

--- a/tests/fixtures/misc.py
+++ b/tests/fixtures/misc.py
@@ -61,8 +61,8 @@ def get_partition_size(df, num_partitions=5):
 
 def _has_rangeindex(df):
     try:
-        index_type = df.schema.pandas_metadata['index_columns'][0]['kind']
-        return index_type == 'range'
+        index_type = df.schema.pandas_metadata["index_columns"][0]["kind"]
+        return index_type == "range"
     except TypeError:
         return False
 

--- a/tests/fixtures/split_table.py
+++ b/tests/fixtures/split_table.py
@@ -10,7 +10,9 @@ from . import _utils
 from .convert_table import convert_table
 
 
-def split_table(df, rows=None, cols=None, index_name=None, keep_index=False, iloc=False):
+def split_table(
+    df, rows=None, cols=None, index_name=None, keep_index=False, iloc=False
+):
     if cols is not None and rows is not None:
         df, other = split_cols(df, cols, index_name, keep_index)
         df, _ = split_rows(df, rows, index_name, iloc)
@@ -43,11 +45,14 @@ def split_col_arg(df, cols):
     if isinstance(cols, dict):
         cols = _filter_items_like_pattern(cols, df_cols)
     not_cols = [c for c in df_cols if c not in cols]
-    return not_cols, cols,
+    return (
+        not_cols,
+        cols,
+    )
 
 
 def _filter_items_like_pattern(cols, df_cols):
-    pattern = cols['like']
+    pattern = cols["like"]
     if not isinstance(pattern, str):
         pattern = pattern[0]
     pattern = __sql_str_pattern_to_regexp(pattern)
@@ -113,8 +118,8 @@ def split_pd_rows(df, rows, iloc):
 
     arrow_df = pa.Table.from_pandas(df, preserve_index=True)
     df, other = split_pa_rows(arrow_df, rows=rows, index_name=df.index.name, iloc=iloc)
-    df = convert_table(df, to='pandas', as_series=as_series)
-    other = convert_table(other, to='pandas', as_series=as_series)
+    df = convert_table(df, to="pandas", as_series=as_series)
+    other = convert_table(other, to="pandas", as_series=as_series)
 
     if isinstance(df.index, pd.RangeIndex) and isinstance(other.index, pd.RangeIndex):
         start_value = df.index[-1] + 1
@@ -131,8 +136,8 @@ def split_pl_rows(df, rows, index_name, iloc):
     df = df.to_arrow()
     df, other = split_pa_rows(df, rows=rows, index_name=index_name, iloc=iloc)
 
-    df = convert_table(df, to='polars', as_series=as_series)
-    other = convert_table(other, to='polars', as_series=as_series)
+    df = convert_table(df, to="polars", as_series=as_series)
+    other = convert_table(other, to="polars", as_series=as_series)
     return df, other
 
 
@@ -142,7 +147,7 @@ def split_pa_rows(df, rows, index_name, iloc):
 
     if index_name is None or iloc:
         if DEFAULT_ARROW_INDEX_NAME in df.column_names:
-            index_name = '__rangeindex__'
+            index_name = "__rangeindex__"
         else:
             index_name = DEFAULT_ARROW_INDEX_NAME
         df = df.add_column(0, index_name, [pd.RangeIndex(len(df))])
@@ -154,7 +159,7 @@ def split_pa_rows(df, rows, index_name, iloc):
     mask = pa.compute.invert(mask)
     df = df.filter(mask)
 
-    if index_name in (DEFAULT_ARROW_INDEX_NAME, '__rangeindex__'):
+    if index_name in (DEFAULT_ARROW_INDEX_NAME, "__rangeindex__"):
         if _utils.is_rangeindex(df[index_name]):
             df = df.drop([index_name])
             other = other.drop([index_name])
@@ -202,13 +207,13 @@ def _filter_arrow_table(df, rows, index_col_name):
     keyword = tuple(rows.keys())[0]
     rows = rows[keyword]
 
-    if keyword == 'before':
+    if keyword == "before":
         upper_bound = __compute_upper_bound(rows[0], index)
         df = df[:upper_bound]
-    elif keyword == 'after':
+    elif keyword == "after":
         lower_bound = __compute_lower_bound(rows[0], index)
         df = df[lower_bound:]
-    elif keyword == 'between':
+    elif keyword == "between":
         lower_bound = __compute_lower_bound(rows[0], index)
         upper_bound = __compute_upper_bound(rows[1], index)
         df = df[lower_bound:upper_bound]

--- a/tests/fixtures/update_values.py
+++ b/tests/fixtures/update_values.py
@@ -49,10 +49,9 @@ def _update_col(df):
 
 def __get_dtype(df):
     dtype = df.dtype.kind
-    DTYPES = {'i': 'int', 'f': 'float', 'b': 'bool',
-              'O': 'string', 'M': 'datetime'}
+    DTYPES = {"i": "int", "f": "float", "b": "bool", "O": "string", "M": "datetime"}
     dtype = DTYPES[dtype]
-    if dtype == 'int':
+    if dtype == "int":
         if df.min() >= 0:
-            dtype = 'uint'
+            dtype = "uint"
     return dtype

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,12 +1,18 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_df_equals,
+    get_partition_size,
+    make_table,
+    split_table,
+)
 
 
 @pytest.mark.integration
 def test_windows_permission_error(store):
     # Arrange
-    original_df = make_table(rows=100, astype='arrow')
-    update_df = make_table(rows=20, astype='pandas')
+    original_df = make_table(rows=100, astype="arrow")
+    update_df = make_table(rows=20, astype="pandas")
 
     partition_size = get_partition_size(original_df, num_partitions=100)
     table = store.select_table(TABLE_NAME)
@@ -25,15 +31,15 @@ def test_windows_permission_error(store):
 def test_linux_memory_mapping(store):
     """Tests that altering an array doesn't change the underlying file"""
     # Arrange
-    df = make_table(rows=100, astype='arrow')
-    original_df, insert_df = split_table(df, cols=['c4'])
+    df = make_table(rows=100, astype="arrow")
+    original_df, insert_df = split_table(df, cols=["c4"])
 
     partition_size = get_partition_size(original_df, num_partitions=100)
     table = store.select_table(TABLE_NAME)
     table.write(original_df, partition_size=partition_size)
     # Act
     df = table.read_arrow(mmap=True)
-    df1 = original_df.append_column('c4', insert_df['c4'])
+    df1 = original_df.append_column("c4", insert_df["c4"])
     # Assert
     assert_df_equals(df, original_df)
     assert df != df1

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -1,16 +1,32 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_df_equals,
+    assert_table_equals,
+    convert_table,
+    default_index,
+    format_arrow_table,
+    get_index_name,
+    get_partition_size,
+    make_table,
+    shuffle_cols,
+    sort_table,
+    sorted_datetime_index,
+    sorted_string_index,
+    split_table,
+)
 
 import pandas as pd
 
 
-@pytest.mark.parametrize("index",
-                         [default_index, sorted_datetime_index, sorted_string_index])
+@pytest.mark.parametrize(
+    "index", [default_index, sorted_datetime_index, sorted_string_index]
+)
 @pytest.mark.parametrize("astype", ["arrow", "polars", "pandas"])
 def test_append_table(store, index, astype):
     # Arrange
     expected = make_table(index, astype=astype)
-    original_df, append_df = split_table(expected, rows={'after': 20}, iloc=True)
+    original_df, append_df = split_table(expected, rows={"after": 20}, iloc=True)
     append_df = shuffle_cols(append_df)
 
     partition_size = get_partition_size(original_df)
@@ -18,7 +34,7 @@ def test_append_table(store, index, astype):
     table = store.select_table(TABLE_NAME)
     table.write(original_df, partition_size=partition_size, index=index_name)
     # Act
-    table.append(append_df, warnings='ignore')
+    table.append(append_df, warnings="ignore")
     # Assert
     assert_table_equals(table, expected)
 
@@ -26,7 +42,7 @@ def test_append_table(store, index, astype):
 @pytest.mark.parametrize("astype", ["polars[series]", "pandas[series]", "arrow"])
 def test_append_series(store, astype):
     expected = make_table(astype=astype, cols=1)
-    original_df, append_df = split_table(expected, rows={'after': 20})
+    original_df, append_df = split_table(expected, rows={"after": 20})
     partition_size = get_partition_size(original_df)
 
     table = store.select_table(TABLE_NAME)
@@ -38,33 +54,33 @@ def test_append_series(store, astype):
 
 
 def test_store_append_table(store):
-    expected = make_table(default_index, astype='pandas')
-    original_df, append_df = split_table(expected, rows={'after': 20})
+    expected = make_table(default_index, astype="pandas")
+    original_df, append_df = split_table(expected, rows={"after": 20})
 
     store.write_table(TABLE_NAME, original_df)
     # Act
-    store.append_table(TABLE_NAME, append_df, warnings='ignore')
+    store.append_table(TABLE_NAME, append_df, warnings="ignore")
     # Assert
     df = store.read_pandas(TABLE_NAME)
     assert_df_equals(df, expected)
 
 
 def test_append_custom_values_to_default_index(store):
-    df = make_table(default_index, astype='pandas')
-    original_df, extra_df = split_table(df, rows={'after': 20})
-    append_df1, append_df2 = split_table(extra_df, rows={'after': 25})
+    df = make_table(default_index, astype="pandas")
+    original_df, extra_df = split_table(df, rows={"after": 20})
+    append_df1, append_df2 = split_table(extra_df, rows={"after": 25})
     append_df2.index = [29, 27, 37, 33, 31]
 
     expected = pd.concat([original_df, append_df1, append_df2])
     expected = sort_table(expected)
-    expected = convert_table(expected, to='arrow')
+    expected = convert_table(expected, to="arrow")
     expected = format_arrow_table(expected)
 
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act
-    table.append(append_df1, warnings='ignore')
-    table.append(append_df2, warnings='ignore')
+    table.append(append_df1, warnings="ignore")
+    table.append(append_df2, warnings="ignore")
     # Assert
     assert_table_equals(table, expected)
 
@@ -76,8 +92,8 @@ def _non_matching_index_dtype():
 
 def _non_matching_column_dtypes():
     df = make_table(rows=15, cols=5, astype="pandas")
-    df.columns = ['c2', 'c4', 'c3', 'c0', 'c1']
-    df = df[['c0', 'c1', 'c2', 'c3', 'c4']]
+    df.columns = ["c2", "c4", "c3", "c0", "c1"]
+    df = df[["c0", "c1", "c2", "c3", "c4"]]
     df = df.tail(5)
     return df
 
@@ -97,14 +113,14 @@ def _index_value_already_in_stored_data():
 def _column_name_not_in_stored_data():
     df = make_table(cols=5, astype="pandas")
     df = df.tail(5)
-    df.columns = ['c0', 'c1', 'c2', 'c3', 'invalid_col_name']
+    df.columns = ["c0", "c1", "c2", "c3", "invalid_col_name"]
     return df
 
 
 def _index_name_not_the_same_as_stored_index():
     df = make_table(astype="pandas")
     df = df.tail(5)
-    df.index.name = 'new_index_name'
+    df.index.name = "new_index_name"
     return df
 
 
@@ -118,7 +134,7 @@ def _duplicate_index_values():
 def _duplicate_column_names():
     df = make_table(cols=5, astype="pandas")
     df = df.tail(5)
-    df.columns = ['c0', 'c1', 'c2', 'c2', 'c4']
+    df.columns = ["c0", "c1", "c2", "c2", "c4"]
     return df
 
 
@@ -156,7 +172,7 @@ def _num_cols_doesnt_match():
 def test_can_append_table(store, append_df, exception):
     # Arrange
     append_df = append_df()
-    original_df = make_table(rows=10, astype='pandas')
+    original_df = make_table(rows=10, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_astype.py
+++ b/tests/test_astype.py
@@ -1,5 +1,13 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DEFAULT_ARROW_INDEX_NAME,
+    TABLE_NAME,
+    assert_table_equals,
+    change_dtype,
+    get_partition_size,
+    make_table,
+    to_arrow_dtype,
+)
 
 import polars as pl
 import pyarrow as pa
@@ -7,23 +15,23 @@ import numpy as np
 
 
 TYPE_MAP = {
-    pa.float16(): 'float',
-    pa.float32(): 'float',
-    pa.float64(): 'float',
-    pa.int16(): 'int',
-    pa.int32(): 'int',
-    pa.int64(): 'int',
-    pa.uint32(): 'uint',
-    pa.bool_(): 'bool',
-    pa.date32(): 'datetime',
-    pa.date64(): 'datetime',
-    pa.time32('ms'): 'datetime',
-    pa.time64('us'): 'datetime',
-    pa.timestamp('us'): 'datetime',
-    pa.string(): 'string',
-    pa.large_string(): 'string',
-    pa.binary(): 'string',
-    pa.large_binary(): 'string',
+    pa.float16(): "float",
+    pa.float32(): "float",
+    pa.float64(): "float",
+    pa.int16(): "int",
+    pa.int32(): "int",
+    pa.int64(): "int",
+    pa.uint32(): "uint",
+    pa.bool_(): "bool",
+    pa.date32(): "datetime",
+    pa.date64(): "datetime",
+    pa.time32("ms"): "datetime",
+    pa.time64("us"): "datetime",
+    pa.timestamp("us"): "datetime",
+    pa.string(): "string",
+    pa.large_string(): "string",
+    pa.binary(): "string",
+    pa.large_binary(): "string",
 }
 kwargs_as_list = True
 
@@ -41,7 +49,7 @@ kwargs_as_list = True
         (pa.bool_(), pa.string()),
         (pa.int64(), pa.bool_()),
         (pa.date32(), pa.date64()),
-        (pa.date32(), pa.timestamp('us')),
+        (pa.date32(), pa.timestamp("us")),
         (pa.date64(), pa.date32()),
         (pa.binary(), pa.large_binary()),
         (pa.binary(), pa.string()),
@@ -54,15 +62,16 @@ kwargs_as_list = True
         (np.uint32, np.int32),
         (bool, np.int16),
         (np.int64, bool),
-    ]
+    ],
 )
 def test_change_pa_dtype(store, from_dtype, to_dtype):
     # Arrange
-    COLS = ['c1', 'c2']
-    original_df = make_table(rows=60, cols=3, astype="arrow",
-                             dtype=_get_dtype_str(from_dtype))
-    original_df = _change_dtype(original_df, from_dtype)
-    expected = _change_dtype(original_df, to_dtype, cols=COLS)
+    COLS = ["c1", "c2"]
+    original_df = make_table(
+        rows=60, cols=3, astype="arrow", dtype=_get_dtype_str(from_dtype)
+    )
+    original_df = change_dtype(original_df, from_dtype)
+    expected = change_dtype(original_df, to_dtype, cols=COLS)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
@@ -72,69 +81,43 @@ def test_change_pa_dtype(store, from_dtype, to_dtype):
     # Act
     table.astype(cols, to=dtype)
     # Assert
-    assert_table_equals(table, expected, astype='all')
+    assert_table_equals(table, expected, astype="all")
 
 
 def _get_dtype_str(dtype):
-    dtype = __convert_to_arrow_dtype(dtype)
+    dtype = to_arrow_dtype(dtype)
     return TYPE_MAP[dtype]
-
-
-def _change_dtype(df, to, index_name='index', cols=None):
-    arrow_dtype = __convert_to_arrow_dtype(to)
-    schema = df.schema
-    cols = cols if cols else schema.names
-    for idx, field in enumerate(schema):
-        if field.name in cols and field.name != index_name:
-            field = field.with_type(arrow_dtype)
-            schema = schema.set(idx, field)
-    df = df.cast(schema)
-    # Casting does not refresh pandas metadata; drop it so conversions follow
-    # the Arrow types (needed for binary/string roundtrips on pandas 2.2+/3).
-    metadata = df.schema.metadata
-    if metadata and b'pandas' in metadata:
-        metadata = {key: value for key, value in metadata.items() if key != b'pandas'}
-        df = df.replace_schema_metadata(metadata or None)
-    return df
-
-
-def __convert_to_arrow_dtype(dtype):
-    try:
-        dtype = pa.from_numpy_dtype(dtype)
-    except Exception:
-        pass
-    return dtype
 
 
 def _format_cols_and_to_key_args(cols, to):
     """Selects every other test to format arguments as one of either:
-        * cols=['c1', 'c2'], to=[dtype1, dtype2]
-        * cols = {'c1': dtype1, 'c2': dtype2}
+    * cols=['c1', 'c2'], to=[dtype1, dtype2]
+    * cols = {'c1': dtype1, 'c2': dtype2}
     """
     global kwargs_as_list
     kwargs_as_list = not kwargs_as_list
-    kwarg_format = 'list' if kwargs_as_list else 'dict'
+    kwarg_format = "list" if kwargs_as_list else "dict"
 
-    if kwarg_format == 'dict':
+    if kwarg_format == "dict":
         cols = {col: to for col in cols}
         to = None
-    elif kwarg_format == 'list':
+    elif kwarg_format == "list":
         to = [to] * len(cols)
     return cols, to
 
 
-NEW_DTYPES_PROVIDED_TWICE = [{'c0': pa.int16()}, [pa.int16()]]
-NEW_DTYPES_NOT_PROVIDED = [['c0', 'c1'], None]
-INVALID_COLS_ARGUMENT_DTYPE = ['c0', [pa.int16()]]
+NEW_DTYPES_PROVIDED_TWICE = [{"c0": pa.int16()}, [pa.int16()]]
+NEW_DTYPES_NOT_PROVIDED = [["c0", "c1"], None]
+INVALID_COLS_ARGUMENT_DTYPE = ["c0", [pa.int16()]]
 INVALID_COLS_KEYS_ARGUMENT_DTYPE = [{1: pa.int32}, None]
-INVALID_COLS_VALUES_ARGUMENT_DTYPE = [{'c0': 123}, None]
-INVALID_TO_ARGUMENT_DTYPE = [['c0'], pa.int16()]
-INVALID_TO_ITEMS_DTYPE = [['c0'], [123]]
-NUMBER_OF_COLS_AND_DTYPES_DONT_MATCH = [['c0', 'c1'], [pa.int16()]]
-FORBIDDEN_INDEX_DTYPE = [[DEFAULT_ARROW_INDEX_NAME], [pa.float32()]]
-NON_ARROW_DTYPE = [['c0'], [pl.Float32()]]
-INVALID_NEW_DTYPE = [['c0'], [pa.float32()]]
-DUPLICATE_COL_NAMES = [['c0', 'c0'], [pa.int16(), pa.int32()]]
+INVALID_COLS_VALUES_ARGUMENT_DTYPE = [{"c0": 123}, None]
+INVALID_TO_ARGUMENT_DTYPE = [["c0"], pa.int16()]
+INVALID_TO_ITEMS_DTYPE = [["c0"], [123]]
+NUMBER_OF_COLS_AND_DTYPES_DONT_MATCH = [["c0", "c1"], [pa.int16()]]
+FORBIDDEN_INDEX_DTYPE = [[DEFAULT_ARROW_INDEX_NAME], [pa.list_(pa.int64())]]
+NON_ARROW_DTYPE = [["c0"], [pl.Float32()]]
+INVALID_NEW_DTYPE = [["c0"], [pa.float32()]]
+DUPLICATE_COL_NAMES = [["c0", "c0"], [pa.int16(), pa.int32()]]
 
 
 @pytest.mark.parametrize(
@@ -165,12 +148,12 @@ DUPLICATE_COL_NAMES = [['c0', 'c0'], [pa.int16(), pa.int32()]]
         "FORBIDDEN_INDEX_DTYPE",
         "NON_ARROW_DTYPE",
         "INVALID_NEW_DTYPE",
-        "DUPLICATE_COL_NAMES"
-    ]
+        "DUPLICATE_COL_NAMES",
+    ],
 )
 def test_can_change_dtype(store, args, exception):
     # Arrange
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     col_names = args[0]

--- a/tests/test_db_and_connection.py
+++ b/tests/test_db_and_connection.py
@@ -1,4 +1,4 @@
-from .fixtures import *
+from .fixtures import DB_PATH
 
 import os
 import shutil
@@ -115,4 +115,4 @@ def test_list_stores(create_db, connect_to_db):
     # Act
     stores = fs.list_stores(like="sto%")
     # Assert
-    assert stores == ["stocks", 'store']
+    assert stores == ["stocks", "store"]

--- a/tests/test_drop.py
+++ b/tests/test_drop.py
@@ -1,5 +1,16 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_table_equals,
+    continuous_datetime_index,
+    continuous_string_index,
+    default_index,
+    fake_default_index,
+    get_partition_size,
+    make_table,
+    sorted_string_index,
+    split_table,
+)
 
 import pandas as pd
 
@@ -7,38 +18,37 @@ ARGS = [
     (default_index, [10, 24, 0, 13], None),
     (default_index, [], None),
     (default_index, pd.RangeIndex(10, 13), None),
-    (default_index, {'before': 10}, None),
-    (default_index, {'after': [10]}, None),
-    (default_index, {'between': [10, 13]}, None),
-    (continuous_string_index, pd.Index(['ab', 'bd', 'al']), None),
-    (continuous_string_index, {'before': ['al']}, None),
-    (continuous_string_index, {'after': 'al'}, None),
-    (continuous_string_index, {'between': ['aj', 'ba']}, None),
-    (continuous_string_index, {'between': ['a', 'b']}, None),
-    (sorted_string_index, {'between': ['a', 'f']}, None),
-    (continuous_datetime_index, pd.DatetimeIndex(['2021-01-01', '2021-01-17']), None),
-    (continuous_datetime_index, {'before': pd.Timestamp('2021-01-17')}, None),
-    (continuous_datetime_index, {'after': '2021-01-17'}, None),
-    (continuous_datetime_index, {'between': ['2021-01-10', '2021-01-14']}, None),
-    (default_index, None, ['c0', 'c3', 'c1']),
-    (default_index, None, {'like': 'c?'}),
-    (default_index, None, {'like': '%1'}),
-    (default_index, None, {'like': '?1%'}),
-    (default_index, {'between': [10, 13]}, {'like': 'c?'}),
+    (default_index, {"before": 10}, None),
+    (default_index, {"after": [10]}, None),
+    (default_index, {"between": [10, 13]}, None),
+    (continuous_string_index, pd.Index(["ab", "bd", "al"]), None),
+    (continuous_string_index, {"before": ["al"]}, None),
+    (continuous_string_index, {"after": "al"}, None),
+    (continuous_string_index, {"between": ["aj", "ba"]}, None),
+    (continuous_string_index, {"between": ["a", "b"]}, None),
+    (sorted_string_index, {"between": ["a", "f"]}, None),
+    (continuous_datetime_index, pd.DatetimeIndex(["2021-01-01", "2021-01-17"]), None),
+    (continuous_datetime_index, {"before": pd.Timestamp("2021-01-17")}, None),
+    (continuous_datetime_index, {"after": "2021-01-17"}, None),
+    (continuous_datetime_index, {"between": ["2021-01-10", "2021-01-14"]}, None),
+    (default_index, None, ["c0", "c3", "c1"]),
+    (default_index, None, {"like": "c?"}),
+    (default_index, None, {"like": "%1"}),
+    (default_index, None, {"like": "?1%"}),
+    (default_index, {"between": [10, 13]}, {"like": "c?"}),
     (default_index, None, []),
 ]
 
 
-@pytest.mark.parametrize(
-    ['index', 'rows', 'cols'], ARGS)
+@pytest.mark.parametrize(["index", "rows", "cols"], ARGS)
 def test_drop(store, index, rows, cols):
     # Arrange
-    original_df = make_table(index, cols=12, astype='pandas')
+    original_df = make_table(index, cols=12, astype="pandas")
     expected, _ = split_table(original_df, rows=rows, cols=cols)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.drop(rows=rows, cols=cols)
     # Assert
@@ -46,46 +56,47 @@ def test_drop(store, index, rows, cols):
 
 
 @pytest.mark.parametrize(
-    'rows',
-    ({'before': 5},
-     {'before': -1},
-     {'after': 25},
-     {'between': [-3, -1]},
-     {'between': [15, 21]},
-     {'between': [27, 35]},
-     [],
-     [4, 4],
-     [4, 29],
-     [29, 26, 27, 28],
-     )
+    "rows",
+    (
+        {"before": 5},
+        {"before": -1},
+        {"after": 25},
+        {"between": [-3, -1]},
+        {"between": [15, 21]},
+        {"between": [27, 35]},
+        [],
+        [4, 4],
+        [4, 29],
+        [29, 26, 27, 28],
+    ),
 )
 def test_default_index_behavior_when_dropping(store, rows):
     # Arrange
-    original_df = make_table(fake_default_index, cols=5, astype='arrow')
+    original_df = make_table(fake_default_index, cols=5, astype="arrow")
     expected, _ = split_table(original_df, rows=rows)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.drop(rows=rows)
     # Assert
     assert_table_equals(table, expected)
 
 
-INVALID_ROWS_DTYPE = 'c1, c2, c3'
-INVALID_ROWS_ELEMENTS_DTYPE = ['3', '19', '25']
+INVALID_ROWS_DTYPE = "c1, c2, c3"
+INVALID_ROWS_ELEMENTS_DTYPE = ["3", "19", "25"]
 ROWS_NOT_IN_TABLE = [2, 5, 7, 10, 459]
 DROP_ALL_ROWS = list(pd.RangeIndex(0, 30))
-INVALID_COLS_DTYPE = 'c1, c2'
-INVALID_COLS_ELEMENTS_DTYPE = ['c1', 2]
-DROP_INDEX = ['c1', 'index']
-COL_NOT_IN_TABLE = ['c1', 'Non-existant col']
-DROP_ALL_COLS = {'like': 'c%'}
+INVALID_COLS_DTYPE = "c1, c2"
+INVALID_COLS_ELEMENTS_DTYPE = ["c1", 2]
+DROP_INDEX = ["c1", "index"]
+COL_NOT_IN_TABLE = ["c1", "Non-existant col"]
+DROP_ALL_COLS = {"like": "c%"}
 
 
 @pytest.mark.parametrize(
-    ('rows', 'cols', 'exception'),
+    ("rows", "cols", "exception"),
     [
         (INVALID_ROWS_DTYPE, None, TypeError),
         (INVALID_ROWS_ELEMENTS_DTYPE, None, TypeError),
@@ -95,23 +106,24 @@ DROP_ALL_COLS = {'like': 'c%'}
         (None, INVALID_COLS_ELEMENTS_DTYPE, TypeError),
         (None, DROP_INDEX, ValueError),
         (None, COL_NOT_IN_TABLE, IndexError),
-        (None, DROP_ALL_COLS, IndexError)
+        (None, DROP_ALL_COLS, IndexError),
     ],
     ids=[
-        'INVALID_ROWS_DTYPE',
-        'INVALID_ROWS_ELEMENTS_DTYPE',
-        'ROWS_NOT_IN_TABLE',
-        'DROP_NO_ROWS',
-        'INVALID_COLS_DTYPE',
-        'INVALID_COLS_ELEMENTS_DTYPE',
-        'DROP_INDEX',
-        'COL_NOT_IN_TABLE',
-        'DROP_ALL_COLS',
-    ])
+        "INVALID_ROWS_DTYPE",
+        "INVALID_ROWS_ELEMENTS_DTYPE",
+        "ROWS_NOT_IN_TABLE",
+        "DROP_NO_ROWS",
+        "INVALID_COLS_DTYPE",
+        "INVALID_COLS_ELEMENTS_DTYPE",
+        "DROP_INDEX",
+        "COL_NOT_IN_TABLE",
+        "DROP_ALL_COLS",
+    ],
+)
 def test_can_drop(store, rows, cols, exception):
     # Arrange
-    original_df = make_table(cols=5, astype='pandas')
-    original_df.index.name = 'index'
+    original_df = make_table(cols=5, astype="pandas")
+    original_df.index.name = "index"
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_general_table_methods.py
+++ b/tests/test_general_table_methods.py
@@ -1,5 +1,13 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_table_equals,
+    default_index,
+    get_index_name,
+    get_partition_size,
+    make_table,
+    sorted_datetime_index,
+)
 
 
 def test_rename_table(store):
@@ -29,8 +37,16 @@ def test_list_tables_like(store):
     # Arrange
     df = make_table(sorted_datetime_index)
     index_name = get_index_name(df)
-    TABLE_NAMES = ("a_table", "AAPL", "MSFT", "TSLA", "AMZN", "FB",
-                   "2019-01-01", "saab")
+    TABLE_NAMES = (
+        "a_table",
+        "AAPL",
+        "MSFT",
+        "TSLA",
+        "AMZN",
+        "FB",
+        "2019-01-01",
+        "saab",
+    )
 
     for table_name in TABLE_NAMES:
         store.write_table(table_name, df, index=index_name)
@@ -99,7 +115,7 @@ def test_get_columns(store):
 
 
 @pytest.mark.parametrize("index", [default_index, sorted_datetime_index])
-@pytest.mark.parametrize("astype", ['arrow', 'pandas'])
+@pytest.mark.parametrize("astype", ["arrow", "pandas"])
 @pytest.mark.parametrize("num_partitions", [5, 2, -1])
 def test_repartition(store, index, astype, num_partitions):
     # Arrange

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,78 +1,82 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_table_equals,
+    continuous_datetime_index,
+    continuous_string_index,
+    default_index,
+    get_partition_size,
+    insert_column_names_at,
+    make_table,
+    merge_rows,
+    sort_table,
+    split_table,
+    unsorted_int_index,
+    unsorted_string_index,
+)
 
-import pandas as pd
 
-
-@pytest.mark.parametrize(["index", "row_indices"],
-                         [[default_index, [4, 1, 7, 8, 3]],
-                          [unsorted_int_index, [0, 1, 2, 3, 4]],
-                          [continuous_string_index, ['ab', 'al']],
-                          [continuous_datetime_index, ['2021-01-10', '2021-01-14']]]
-                         )
-@pytest.mark.parametrize(["num_rows", "num_cols", "num_partitions"],
-                         [[75, 5, 5],
-                          [75, 5, 30],
-                          [30, 1, 1],
-                          [30, 1, 5]]
-                         )
+@pytest.mark.parametrize(
+    ["index", "row_indices"],
+    [
+        [default_index, [4, 1, 7, 8, 3]],
+        [unsorted_int_index, [0, 1, 2, 3, 4]],
+        [continuous_string_index, ["ab", "al"]],
+        [continuous_datetime_index, ["2021-01-10", "2021-01-14"]],
+    ],
+)
+@pytest.mark.parametrize(
+    ["num_rows", "num_cols", "num_partitions"],
+    [[75, 5, 5], [75, 5, 30], [30, 1, 1], [30, 1, 5]],
+)
 def test_insert_rows(store, index, row_indices, num_rows, num_cols, num_partitions):
     # Arrange
-    expected = make_table(index, rows=num_rows, cols=num_cols,
-                          astype='pandas[series]')
+    expected = make_table(index, rows=num_rows, cols=num_cols, astype="pandas[series]")
     original_df, insert_df = split_table(expected, rows=row_indices)
     expected = sort_table(expected)
 
     partition_size = get_partition_size(original_df, num_partitions)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert(insert_df)
     # Assert
     assert_table_equals(table, expected)
 
 
-@pytest.mark.parametrize(["index", "col_names", "col_idx"],
-                         [[unsorted_int_index, ['n0', 'n1'], 3],
-                          [continuous_datetime_index, ['n0'], -1],
-                          [unsorted_string_index, ['n0', 'n1'], -1],
-                          [default_index, ['n0'], 0]
-                          ]
-                         )
+@pytest.mark.parametrize(
+    ["index", "col_names", "col_idx"],
+    [
+        [unsorted_int_index, ["n0", "n1"], 3],
+        [continuous_datetime_index, ["n0"], -1],
+        [unsorted_string_index, ["n0", "n1"], -1],
+        [default_index, ["n0"], 0],
+    ],
+)
 def test_insert_columns(store, index, col_names, col_idx):
     # Arrange
     num_cols = 5 + len(col_names)
     df = make_table(index=index, cols=num_cols, astype="pandas")
-    expected = _change_cols(df, col_names, col_idx)
+    expected = insert_column_names_at(df, col_names, col_idx)
     original_df, new_cols = split_table(expected, cols=col_names)
     expected = sort_table(expected)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert(new_cols, idx=col_idx)
     # Assert
     assert_table_equals(table, expected)
 
 
-def _change_cols(df, col_names, col_idx):
-    num_cols = len(col_names)
-    cols = df.columns.tolist()
-    end = col_idx + num_cols
-    if col_idx < 0:
-        col_idx = -len(col_names)
-        end = None
-    cols[col_idx:end] = col_names
-    df.columns = cols
-    return df
-
-
-@pytest.mark.parametrize(["index", "col_names", "col_indices"],
-                         [[unsorted_int_index, ['n0', 'n1'], [1, 3]],
-                          [default_index, ['n0', 'n1', 'n2'], [0, 2, 4]],
-                          ]
-                         )
+@pytest.mark.parametrize(
+    ["index", "col_names", "col_indices"],
+    [
+        [unsorted_int_index, ["n0", "n1"], [1, 3]],
+        [default_index, ["n0", "n1", "n2"], [0, 2, 4]],
+    ],
+)
 def test_insert_columns_with_idx_sequence(store, index, col_names, col_indices):
     # Arrange
     num_cols = 5 + len(col_names)
@@ -83,7 +87,7 @@ def test_insert_columns_with_idx_sequence(store, index, col_names, col_indices):
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert(new_cols, idx=col_indices)
     # Assert
@@ -92,8 +96,8 @@ def test_insert_columns_with_idx_sequence(store, index, col_names, col_indices):
 
 def _build_expected_with_col_positions(df, col_names, col_indices):
     cols = df.columns.tolist()
-    new_col_source = cols[-len(col_names):]
-    base_cols = cols[:-len(col_names)]
+    new_col_source = cols[-len(col_names) :]
+    base_cols = cols[: -len(col_names)]
     df = df.rename(columns=dict(zip(new_col_source, col_names)))
     expected = df[base_cols].copy()
     for col_name, col_idx in zip(col_names, col_indices):
@@ -104,32 +108,24 @@ def _build_expected_with_col_positions(df, col_names, col_indices):
 @pytest.mark.parametrize("row_indices", ([-2, -1], [30, 33], [33, 30, 32, 31]))
 def test_insert_ignores_idx_when_inserting_rows(store, row_indices):
     # Arrange
-    original_df = make_table(default_index, rows=30, astype='pandas')
-    insert_df = make_table(default_index, rows=len(row_indices), astype='pandas')
+    original_df = make_table(default_index, rows=30, astype="pandas")
+    insert_df = make_table(default_index, rows=len(row_indices), astype="pandas")
     insert_df.index = row_indices
 
-    expected = _insert(original_df, insert_df)
+    expected = merge_rows(original_df, insert_df, as_arrow=True)
 
     partition_size = get_partition_size(original_df, 5)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert(insert_df, idx=0)
     # Assert
     assert_table_equals(table, expected)
 
 
-def _insert(df, other):
-    new_df = pd.concat([df, other])
-    new_df = sort_table(new_df)
-    new_df = convert_table(new_df, to='arrow')
-    new_df = format_arrow_table(new_df)
-    return new_df
-
-
 def _two_new_cols():
-    df = make_table(cols=2, astype='pandas')
-    df.columns = ['new_c0', 'new_c1']
+    df = make_table(cols=2, astype="pandas")
+    df.columns = ["new_c0", "new_c1"]
     return df
 
 
@@ -142,12 +138,12 @@ def _two_new_cols():
     ids=[
         "_idx_too_short",
         "_idx_too_long",
-    ]
+    ],
 )
 def test_can_insert_with_invalid_idx(store, insert_cols_df, idx, exception):
     # Arrange
     insert_cols_df = insert_cols_df()
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_insert_cols.py
+++ b/tests/test_insert_cols.py
@@ -1,14 +1,29 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DEFAULT_ARROW_INDEX_NAME,
+    TABLE_NAME,
+    assert_table_equals,
+    continuous_datetime_index,
+    default_index,
+    get_partition_size,
+    make_table,
+    sort_table,
+    sorted_string_index,
+    split_table,
+    unsorted_int_index,
+    unsorted_string_index,
+)
 
 
-@pytest.mark.parametrize(["index", "col_names", "col_idx"],
-                         [[unsorted_int_index, ['n0', 'n1'], 3],
-                          [continuous_datetime_index, ['n0'], -1],
-                          [unsorted_string_index, ['n0', 'n1'], -1],
-                          [default_index, ['n0'], 0]
-                          ]
-                         )
+@pytest.mark.parametrize(
+    ["index", "col_names", "col_idx"],
+    [
+        [unsorted_int_index, ["n0", "n1"], 3],
+        [continuous_datetime_index, ["n0"], -1],
+        [unsorted_string_index, ["n0", "n1"], -1],
+        [default_index, ["n0"], 0],
+    ],
+)
 def test_insert_cols(store, index, col_names, col_idx):
     # Arrange
     num_cols = 5 + len(col_names)
@@ -19,20 +34,22 @@ def test_insert_cols(store, index, col_names, col_idx):
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert_columns(new_cols, idx=col_idx)
     # Assert
     assert_table_equals(table, expected)
 
 
-@pytest.mark.parametrize(["index", "col_names", "col_indices"],
-                         [[unsorted_int_index, ['n0', 'n1'], [1, 3]],
-                          [continuous_datetime_index, ['n0'], [2]],
-                          [unsorted_string_index, ['n0', 'n1', 'n2'], [0, 2, 4]],
-                          [default_index, ['n0'], [0]]
-                          ]
-                         )
+@pytest.mark.parametrize(
+    ["index", "col_names", "col_indices"],
+    [
+        [unsorted_int_index, ["n0", "n1"], [1, 3]],
+        [continuous_datetime_index, ["n0"], [2]],
+        [unsorted_string_index, ["n0", "n1", "n2"], [0, 2, 4]],
+        [default_index, ["n0"], [0]],
+    ],
+)
 def test_insert_cols_with_idx_sequence(store, index, col_names, col_indices):
     # Arrange
     num_cols = 5 + len(col_names)
@@ -43,7 +60,7 @@ def test_insert_cols_with_idx_sequence(store, index, col_names, col_indices):
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert_columns(new_cols, idx=col_indices)
     # Assert
@@ -52,8 +69,8 @@ def test_insert_cols_with_idx_sequence(store, index, col_names, col_indices):
 
 def _build_expected_with_col_positions(df, col_names, col_indices):
     cols = df.columns.tolist()
-    new_col_source = cols[-len(col_names):]
-    base_cols = cols[:-len(col_names)]
+    new_col_source = cols[-len(col_names) :]
+    base_cols = cols[: -len(col_names)]
     df = df.rename(columns=dict(zip(new_col_source, col_names)))
     expected = df[base_cols].copy()
     for col_name, col_idx in zip(col_names, col_indices):
@@ -74,55 +91,55 @@ def _change_cols(df, col_names, col_idx):
 
 
 def _wrong_table_type():
-    df = make_table(cols=1, astype='arrow')
-    df = df.rename_columns(['new_c1'])
+    df = make_table(cols=1, astype="arrow")
+    df = df.rename_columns(["new_c1"])
     return df
 
 
 def _col_name_already_in_table():
-    return make_table(cols=2, astype='pandas')
+    return make_table(cols=2, astype="pandas")
 
 
 def _add_col_named_same_as_index():
-    df = make_table(cols=1, astype='pandas')
+    df = make_table(cols=1, astype="pandas")
     df.columns = [DEFAULT_ARROW_INDEX_NAME]
     return df
 
 
 def _new_cols_contain_duplicate_names():
-    df = make_table(cols=2, astype='pandas')
-    df.columns = ['new_c1', 'new_c1']
+    df = make_table(cols=2, astype="pandas")
+    df.columns = ["new_c1", "new_c1"]
     return df
 
 
 def _non_matching_index_dtype():
-    df = make_table(index=sorted_string_index, cols=2, astype='pandas')
-    df.columns = ['new_c1', 'new_c2']
+    df = make_table(index=sorted_string_index, cols=2, astype="pandas")
+    df.columns = ["new_c1", "new_c2"]
     return df
 
 
 def _num_rows_doesnt_match():
-    df = make_table(rows=42, cols=1, astype='pandas')
-    df.columns = ['new_c1']
+    df = make_table(rows=42, cols=1, astype="pandas")
+    df.columns = ["new_c1"]
     return df
 
 
 def _non_matching_index_values():
-    df = make_table(cols=1, astype='pandas')
+    df = make_table(cols=1, astype="pandas")
     df.index += 50
-    df.columns = ['new_c1']
+    df.columns = ["new_c1"]
     return df
 
 
 def _two_new_cols():
-    df = make_table(cols=2, astype='pandas')
-    df.columns = ['new_c0', 'new_c1']
+    df = make_table(cols=2, astype="pandas")
+    df.columns = ["new_c0", "new_c1"]
     return df
 
 
 def _one_new_col():
-    df = make_table(cols=1, astype='pandas')
-    df.columns = ['new_c1']
+    df = make_table(cols=1, astype="pandas")
+    df.columns = ["new_c1"]
     return df
 
 
@@ -144,13 +161,13 @@ def _one_new_col():
         "_new_cols_contain_duplicate_names",
         "_non_matching_index_dtype",
         "_num_rows_doesnt_match",
-        "_non_matching_index_values"
-    ]
+        "_non_matching_index_values",
+    ],
 )
 def test_can_insert_cols(store, insert_cols_df, exception):
     # Arrange
     insert_cols_df = insert_cols_df()
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert
@@ -163,7 +180,7 @@ def test_can_insert_cols(store, insert_cols_df, exception):
     [
         (_two_new_cols, [0], ValueError),
         (_two_new_cols, [0, 1, 2], ValueError),
-        (_one_new_col, ['a'], TypeError),
+        (_one_new_col, ["a"], TypeError),
         (_one_new_col, [1.5], TypeError),
         (_one_new_col, 1.5, TypeError),
     ],
@@ -173,12 +190,12 @@ def test_can_insert_cols(store, insert_cols_df, exception):
         "_idx_non_int_element",
         "_idx_non_int_in_sequence",
         "_idx_non_int_scalar",
-    ]
+    ],
 )
 def test_can_insert_cols_with_invalid_idx(store, insert_cols_df, idx, exception):
     # Arrange
     insert_cols_df = insert_cols_df()
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_insert_rows.py
+++ b/tests/test_insert_rows.py
@@ -1,5 +1,18 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_table_equals,
+    continuous_datetime_index,
+    continuous_string_index,
+    default_index,
+    get_partition_size,
+    make_table,
+    merge_rows,
+    sort_table,
+    sorted_string_index,
+    split_table,
+    unsorted_int_index,
+)
 
 import pandas as pd
 
@@ -7,28 +20,28 @@ import pandas as pd
 DROPPED_ROWS_INDICES = [2, 5, 7, 10]
 
 
-@pytest.mark.parametrize(["index", "row_indices"],
-                         [[default_index, [4, 1, 7, 8, 3]],
-                          [unsorted_int_index, [0, 1, 2, 3, 4]],
-                          [continuous_string_index, ['ab', 'al']],
-                          [continuous_datetime_index, ['2021-01-10', '2021-01-14']]]
-                         )
-@pytest.mark.parametrize(["num_rows", "num_cols", "num_partitions"],
-                         [[75, 5, 5],
-                          [75, 5, 30],
-                          [30, 1, 1],
-                          [30, 1, 5]]
-                         )
+@pytest.mark.parametrize(
+    ["index", "row_indices"],
+    [
+        [default_index, [4, 1, 7, 8, 3]],
+        [unsorted_int_index, [0, 1, 2, 3, 4]],
+        [continuous_string_index, ["ab", "al"]],
+        [continuous_datetime_index, ["2021-01-10", "2021-01-14"]],
+    ],
+)
+@pytest.mark.parametrize(
+    ["num_rows", "num_cols", "num_partitions"],
+    [[75, 5, 5], [75, 5, 30], [30, 1, 1], [30, 1, 5]],
+)
 def test_insert_table(store, index, row_indices, num_rows, num_cols, num_partitions):
     # Arrange
-    expected = make_table(index, rows=num_rows, cols=num_cols,
-                          astype='pandas[series]')
+    expected = make_table(index, rows=num_rows, cols=num_cols, astype="pandas[series]")
     original_df, insert_df = split_table(expected, rows=row_indices)
     expected = sort_table(expected)
 
     partition_size = get_partition_size(original_df, num_partitions)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert_rows(insert_df)
     # Assert
@@ -38,27 +51,19 @@ def test_insert_table(store, index, row_indices, num_rows, num_cols, num_partiti
 @pytest.mark.parametrize("row_indices", ([-2, -1], [30, 33], [33, 30, 32, 31]))
 def test_default_index_behavior_when_inserting(store, row_indices):
     # Arrange
-    original_df = make_table(default_index, rows=30, astype='pandas')
-    insert_df = make_table(default_index, rows=len(row_indices), astype='pandas')
+    original_df = make_table(default_index, rows=30, astype="pandas")
+    insert_df = make_table(default_index, rows=len(row_indices), astype="pandas")
     insert_df.index = row_indices
 
-    expected = _insert(original_df, insert_df)
+    expected = merge_rows(original_df, insert_df, as_arrow=True)
 
     partition_size = get_partition_size(original_df, 5)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.insert_rows(insert_df)
     # Assert
     assert_table_equals(table, expected)
-
-
-def _insert(df, other):
-    new_df = pd.concat([df, other])
-    new_df = sort_table(new_df)
-    new_df = convert_table(new_df, to='arrow')
-    new_df = format_arrow_table(new_df)
-    return new_df
 
 
 def _insert_table_not_pd_table():
@@ -72,7 +77,7 @@ def _non_matching_index_dtype():
 
 
 def _non_matching_column_dtypes():
-    df = make_table(dtype='string', astype="pandas")
+    df = make_table(dtype="string", astype="pandas")
     df = df.iloc[DROPPED_ROWS_INDICES, :]
     return df
 
@@ -85,14 +90,14 @@ def _index_values_already_in_stored_data():
 def _column_name_not_in_stored_data():
     df = make_table(cols=2, astype="pandas")
     df = df.iloc[DROPPED_ROWS_INDICES, :]
-    df.columns = ['c1', 'non-existant_column']
+    df.columns = ["c1", "non-existant_column"]
     return df
 
 
 def _index_name_not_the_same_as_stored_index():
     df = make_table(astype="pandas")
     df = df.iloc[DROPPED_ROWS_INDICES, :]
-    df.index.name = 'new_index_name'
+    df.index.name = "new_index_name"
     return df
 
 
@@ -106,7 +111,7 @@ def _duplicate_index_values():
 def _duplicate_column_names():
     df = make_table(cols=6, astype="pandas")
     df = df.iloc[DROPPED_ROWS_INDICES, :]
-    df.columns = ['c0', 'c0', 'c1', 'c2', 'c3', 'c4']
+    df.columns = ["c0", "c0", "c1", "c2", "c3", "c4"]
     return df
 
 
@@ -136,7 +141,7 @@ def _duplicate_column_names():
 def test_can_insert_rows(store, insert_df, exception):
     # Arrange
     insert_df = insert_df()
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     original_df = original_df.drop(index=DROPPED_ROWS_INDICES)
     table = store.select_table(TABLE_NAME)
     table.write(original_df)

--- a/tests/test_io_general.py
+++ b/tests/test_io_general.py
@@ -1,18 +1,37 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_df_equals,
+    assert_table_equals,
+    default_index,
+    get_index_name,
+    get_partition_size,
+    make_table,
+    sort_table,
+    sorted_binary_index,
+    sorted_date32_index,
+    sorted_datetime_index,
+    sorted_decimal_index,
+    sorted_float_index,
+    sorted_large_string_index,
+    sorted_time32_index,
+    sorted_timedelta_index,
+    sorted_uint_index,
+    unsorted_int_index,
+    unsorted_string_index,
+)
 
 from contextlib import nullcontext
 import pandas as pd
-import numpy as np
+import pyarrow as pa
 
 
 @pytest.mark.parametrize("astype", ["pandas[series]", "polars[series]", "arrow"])
 @pytest.mark.parametrize("cols", [5, 1])
-@pytest.mark.parametrize("index",
-                         [default_index,
-                          unsorted_int_index,
-                          sorted_datetime_index,
-                          unsorted_string_index])
+@pytest.mark.parametrize(
+    "index",
+    [default_index, unsorted_int_index, sorted_datetime_index, unsorted_string_index],
+)
 def test_basic_io(store, index, cols, astype):
     # Arrange
     original_df = make_table(index, cols=cols, astype=astype)
@@ -22,8 +41,38 @@ def test_basic_io(store, index, cols, astype):
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, index=index_name, partition_size=partition_size,
-                warnings='ignore')
+    table.write(
+        original_df, index=index_name, partition_size=partition_size, warnings="ignore"
+    )
+    # Assert
+    assert_table_equals(table, expected)
+
+
+EXOTIC_INDEX_ASTYPES = [
+    (sorted_timedelta_index, "arrow"),
+    (sorted_time32_index, "arrow"),
+    (sorted_date32_index, "pandas[series]"),
+    (sorted_float_index, "pandas[series]"),
+    (sorted_uint_index, "pandas[series]"),
+    (sorted_decimal_index, "pandas[series]"),
+    (sorted_binary_index, "pandas[series]"),
+    (sorted_large_string_index, "arrow"),
+]
+
+
+@pytest.mark.parametrize(["index", "astype"], EXOTIC_INDEX_ASTYPES)
+def test_basic_io_with_exotic_indices(store, index, astype):
+    # Arrange
+    original_df = make_table(index, cols=5, astype=astype)
+    index_name = get_index_name(original_df)
+    expected = sort_table(original_df, by=index_name)
+
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    # Act
+    table.write(
+        original_df, index=index_name, partition_size=partition_size, warnings="ignore"
+    )
     # Assert
     assert_table_equals(table, expected)
 
@@ -34,12 +83,12 @@ def test_store_io(store, astype, mmap):
     # Arrange
     original_df = make_table(astype=astype)
     # Act
-    store.write_table(TABLE_NAME, original_df, warnings='ignore')
-    if astype.startswith('pandas'):
+    store.write_table(TABLE_NAME, original_df, warnings="ignore")
+    if astype.startswith("pandas"):
         df = store.read_pandas(TABLE_NAME, mmap=mmap)
-    elif astype.startswith('polars'):
+    elif astype.startswith("polars"):
         df = store.read_polars(TABLE_NAME, mmap=mmap)
-    elif astype == 'arrow':
+    elif astype == "arrow":
         df = store.read_arrow(TABLE_NAME, mmap=mmap)
     # Assert
     assert_df_equals(df, original_df)
@@ -58,25 +107,28 @@ def test_empty_df_io(store, astype):
 
 
 def _invalid_table_dtype():
-    df = make_table(astype='pandas')
+    df = make_table(astype="pandas")
     args = [TABLE_NAME, df.values]
     kwargs = dict()
     return args, kwargs
 
 
 def _invalid_index_dtype():
-    df = make_table(astype='pandas')
-    index = np.random.random(size=30)
-    df = df.set_index(index)
+    df = make_table(astype="arrow", rows=15)
+    index = pa.array(
+        [{"a": idx} for idx in range(len(df))],
+        type=pa.struct([("a", pa.int64())]),
+    )
+    df = df.add_column(0, "idx", index)
 
     args = [TABLE_NAME, df]
-    kwargs = dict()
+    kwargs = dict(index="idx")
     return args, kwargs
 
 
 def _duplicate_index():
-    df = make_table(astype='pandas', rows=15)
-    df1 = make_table(astype='pandas', rows=15)
+    df = make_table(astype="pandas", rows=15)
+    df1 = make_table(astype="pandas", rows=15)
     df = pd.concat([df, df1])
 
     args = [TABLE_NAME, df]
@@ -85,17 +137,17 @@ def _duplicate_index():
 
 
 def _index_not_in_cols():
-    df = make_table(cols=2, astype='polars')
-    df.column_names = ['c0', 'c1']
+    df = make_table(cols=2, astype="polars")
+    df.column_names = ["c0", "c1"]
 
     args = [TABLE_NAME, df]
-    kwargs = dict(index='c2')
+    kwargs = dict(index="c2")
     return args, kwargs
 
 
 def _invalid_col_names_dtype():
-    df = make_table(astype='pandas')
-    df.columns = ['c0', 'c1', 'c2', 3, 'c4']
+    df = make_table(astype="pandas")
+    df.columns = ["c0", "c1", "c2", 3, "c4"]
 
     args = [TABLE_NAME, df]
     kwargs = dict()
@@ -103,8 +155,8 @@ def _invalid_col_names_dtype():
 
 
 def _duplicate_col_names():
-    df = make_table(cols=2, astype='pandas')
-    df.columns = ['c0', 'c0']
+    df = make_table(cols=2, astype="pandas")
+    df.columns = ["c0", "c0"]
 
     args = [TABLE_NAME, df]
     kwargs = dict()
@@ -114,14 +166,14 @@ def _duplicate_col_names():
 def _invalid_warnings_arg():
     df = make_table()
     args = [TABLE_NAME, df]
-    kwargs = dict(warnings='abcd')
+    kwargs = dict(warnings="abcd")
     return args, kwargs
 
 
 def _invalid_errors_arg():
     df = make_table()
     args = [TABLE_NAME, df]
-    kwargs = dict(errors='abcd')
+    kwargs = dict(errors="abcd")
     return args, kwargs
 
 
@@ -165,10 +217,10 @@ def test_can_write(store, arguments, exception):
         store.write_table(*arguments, **kwargs)
 
 
-@pytest.mark.parametrize(("errors", "exception"),
-                         [('raise', pytest.raises(FileExistsError)),
-                          ('ignore', nullcontext())]
-                         )
+@pytest.mark.parametrize(
+    ("errors", "exception"),
+    [("raise", pytest.raises(FileExistsError)), ("ignore", nullcontext())],
+)
 def test_trying_to_overwrite_existing_table(store, errors, exception):
     # Arrange
     table = store.select_table(TABLE_NAME)
@@ -181,13 +233,13 @@ def test_trying_to_overwrite_existing_table(store, errors, exception):
 
 
 INVALID_TABLE_NAME_DTYPE = [21, dict()]
-INVALID_ROW_DTYPE = [TABLE_NAME, {'rows': 14}]
-ROW_ELEMENTS_NOT_ALL_SAME_DTYPE = [TABLE_NAME, {'rows': [5, 'ab', 7.13]}]
-ROWS_NOT_SAME_DTYPE_AS_INDEX = [TABLE_NAME, {'rows': ['index', 'not', 'string']}]
-ROWS_NOT_IN_TABLE = [TABLE_NAME, {'rows': [0, 1, 3334]}]
-INVALID_COL_DTYPE = [TABLE_NAME, {'cols': 14}]
-INVALID_COL_ELEMENTS_DTYPE = [TABLE_NAME, {'cols': ['c1', 'C2', 12]}]
-COLS_NOT_IN_TABLE = [TABLE_NAME, {'cols': ['c0', 'c1', 'c3334']}]
+INVALID_ROW_DTYPE = [TABLE_NAME, {"rows": 14}]
+ROW_ELEMENTS_NOT_ALL_SAME_DTYPE = [TABLE_NAME, {"rows": [5, "ab", 7.13]}]
+ROWS_NOT_SAME_DTYPE_AS_INDEX = [TABLE_NAME, {"rows": ["index", "not", "string"]}]
+ROWS_NOT_IN_TABLE = [TABLE_NAME, {"rows": [0, 1, 3334]}]
+INVALID_COL_DTYPE = [TABLE_NAME, {"cols": 14}]
+INVALID_COL_ELEMENTS_DTYPE = [TABLE_NAME, {"cols": ["c1", "C2", 12]}]
+COLS_NOT_IN_TABLE = [TABLE_NAME, {"cols": ["c0", "c1", "c3334"]}]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io_pandas.py
+++ b/tests/test_io_pandas.py
@@ -1,5 +1,16 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_df_equals,
+    continuous_datetime_index,
+    continuous_string_index,
+    default_index,
+    fake_default_index,
+    get_partition_size,
+    make_table,
+    sorted_string_index,
+    split_table,
+)
 
 import pandas as pd
 import numpy as np
@@ -8,7 +19,7 @@ import numpy as np
 def test_that_rangeindex_is_converted_back(store):
     # Arrange
     original_df = make_table(fake_default_index, astype="pandas")
-    original_df.index.name = 'index'
+    original_df.index.name = "index"
     store.write_table(TABLE_NAME, original_df)
     # Act
     df = store.read_pandas(TABLE_NAME)
@@ -22,51 +33,52 @@ def test_that_rangeindex_is_converted_back(store):
 @pytest.mark.parametrize(
     ["index", "rows", "cols"],
     [
-        (default_index, None, ['c0', 'c5', 'c2']),
+        (default_index, None, ["c0", "c5", "c2"]),
         (default_index, None, {"like": "c?"}),
         (default_index, None, {"like": ["%1"]}),
         (default_index, None, {"like": "?1%"}),
-        (default_index, pd.Index([0, 1, 27]), ['c0', 'c5', 'c2']),
-        (default_index, {'after': [12]}, None),
-        (default_index, {'between': [12, 27]}, None),
+        (default_index, pd.Index([0, 1, 27]), ["c0", "c5", "c2"]),
+        (default_index, {"after": [12]}, None),
+        (default_index, {"between": [12, 27]}, None),
         (continuous_datetime_index, ["2021-01-07", "2021-01-20"], None),
-        (continuous_datetime_index, {'before': [pd.Timestamp("2022-02-02")]}, None),
-        (continuous_datetime_index, {'after': pd.Timestamp("2021-01-12")}, None),
-        (continuous_datetime_index, {'between': ["2021-01-12", "2021-01-20"]}, None),
-        (continuous_string_index, ['aa', 'ba'], None),
-        (continuous_string_index, {"before": ['aj']}, None),
-        (continuous_string_index, {"after": 'aj'}, None),
-        (continuous_string_index, {"between": ['a', 'b']}, ['c0']),
-        (continuous_string_index, {"between": ['aj', 'ba']}, None),
-        (sorted_string_index, {"between": ['b', 'u']}, {"like": "c?"})
-    ]
+        (continuous_datetime_index, {"before": [pd.Timestamp("2022-02-02")]}, None),
+        (continuous_datetime_index, {"after": pd.Timestamp("2021-01-12")}, None),
+        (continuous_datetime_index, {"between": ["2021-01-12", "2021-01-20"]}, None),
+        (continuous_string_index, ["aa", "ba"], None),
+        (continuous_string_index, {"before": ["aj"]}, None),
+        (continuous_string_index, {"after": "aj"}, None),
+        (continuous_string_index, {"between": ["a", "b"]}, ["c0"]),
+        (continuous_string_index, {"between": ["aj", "ba"]}, None),
+        (sorted_string_index, {"between": ["b", "u"]}, {"like": "c?"}),
+    ],
 )
 def test_pandas_filtering(store, index, rows, cols):
     # Arrange
-    original_df = make_table(index, cols=15, astype='pandas[series]')
+    original_df = make_table(index, cols=15, astype="pandas[series]")
     _, expected = split_table(original_df, rows=rows, cols=cols)
     expected = expected.squeeze(axis=1)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     df = table.read_pandas(rows=rows, cols=cols)
     # Assert
     assert_df_equals(df, expected)
 
 
-@pytest.mark.parametrize("cols", [['c0'], {"like": "c?"}, {"like": ["%0"]},
-                                  {"like": "?1%"}])
+@pytest.mark.parametrize(
+    "cols", [["c0"], {"like": "c?"}, {"like": ["%0"]}, {"like": "?1%"}]
+)
 def test_pandas_series_filtering_cols(store, cols):
     # Arrange
-    original_df = make_table(cols=1, astype='pandas[series]')
+    original_df = make_table(cols=1, astype="pandas[series]")
     _, expected = split_table(original_df, cols=cols)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     df = table.read_pandas(cols=cols)
     # Assert
     assert_df_equals(df, expected)
@@ -74,13 +86,13 @@ def test_pandas_series_filtering_cols(store, cols):
 
 def test_pandas_series_without_name_io(store):
     # Arrange
-    original_df = make_table(cols=1, astype='pandas[series]')
+    original_df = make_table(cols=1, astype="pandas[series]")
     original_df.name = None
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     df = table.read_pandas()
     # Assert
     assert_df_equals(df, original_df)
@@ -88,21 +100,28 @@ def test_pandas_series_without_name_io(store):
 
 def test_pandas_categorical_col_io(store):
     # Arrange
-    original_df = make_table(cols=5, astype='pandas')
-    original_df['c1'] = pd.cut(original_df['c1'], bins=[-np.inf, -0.5, 0.5, np.inf], labels=['low', 'medium', 'high'])
-    original_df['c2'] = pd.cut(original_df['c2'], bins=[-np.inf, 0, np.inf], labels=[0, 1])
+    original_df = make_table(cols=5, astype="pandas")
+    original_df["c1"] = pd.cut(
+        original_df["c1"],
+        bins=[-np.inf, -0.5, 0.5, np.inf],
+        labels=["low", "medium", "high"],
+    )
+    original_df["c2"] = pd.cut(
+        original_df["c2"], bins=[-np.inf, 0, np.inf], labels=[0, 1]
+    )
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     df = table.read_pandas()
     # Assert
     assert_df_equals(df, original_df)
 
 
-@pytest.mark.parametrize(["num_cols", "astype"],
-                         [(1, 'series'), (1, 'dataframe'), (4, 'dataframe')])
+@pytest.mark.parametrize(
+    ["num_cols", "astype"], [(1, "series"), (1, "dataframe"), (4, "dataframe")]
+)
 def test_pandas_multitype_col_io(store, num_cols, astype):
     # Arrange
     original_df = _create_multitype_col_df(num_cols, astype)
@@ -110,33 +129,33 @@ def test_pandas_multitype_col_io(store, num_cols, astype):
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     df = table.read_pandas()
     # Assert
     assert_df_equals(df, expected)
 
 
 def _create_multitype_col_df(num_cols, astype):
-    df = make_table(cols=5, rows=num_cols, astype='pandas').T  # Transpose
-    df.columns = reversed([f'c{i}' for i in range(num_cols)])
+    df = make_table(cols=5, rows=num_cols, astype="pandas").T  # Transpose
+    df.columns = reversed([f"c{i}" for i in range(num_cols)])
     df = df.sample(5, random_state=42)
-    if astype == 'series':
+    if astype == "series":
         df = df.squeeze()
     return df
 
 
 def test_multitype_col_and_row_io(store):
     # Arrange
-    original_df = make_table(cols=5, rows=2, astype='pandas').T  # Transpose
-    original_df.columns = ['c0', 'c1']
-    original_df['c0'] = _shuffle_col(original_df['c0'], seed=42)
-    original_df['c1'] = _shuffle_col(original_df['c1'], seed=43)
+    original_df = make_table(cols=5, rows=2, astype="pandas").T  # Transpose
+    original_df.columns = ["c0", "c1"]
+    original_df["c0"] = _shuffle_col(original_df["c0"], seed=42)
+    original_df["c1"] = _shuffle_col(original_df["c1"], seed=43)
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act & Assert
     with pytest.raises(ValueError):
-        table.write(original_df, partition_size=partition_size, warnings='ignore')
+        table.write(original_df, partition_size=partition_size, warnings="ignore")
 
 
 def _shuffle_col(df, seed=42):

--- a/tests/test_io_polars_arrow.py
+++ b/tests/test_io_polars_arrow.py
@@ -1,22 +1,37 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DEFAULT_ARROW_INDEX_NAME,
+    TABLE_NAME,
+    assert_df_equals,
+    assert_table_equals,
+    continuous_datetime_index,
+    convert_table,
+    drop_default_index_if_exists,
+    fake_default_index,
+    get_index_name,
+    get_partition_size,
+    make_table,
+    sorted_string_index,
+    split_table,
+)
 
 
 @pytest.mark.parametrize(
     ["index", "rows", "cols", "astype"],
     [
-        (fake_default_index, [0, 5, 12], ['c0', 'c4', 'c2'], 'polars'),
-        (fake_default_index, {'before': 12}, {"like": "c?"}, 'arrow'),
-        (sorted_string_index, {"between": ['a', 'f']}, {"like": "c?"}, 'polars'),
-        (continuous_datetime_index, ["2021-01-07", "2021-01-20"], None, 'arrow'),
-    ]
+        (fake_default_index, [0, 5, 12], ["c0", "c4", "c2"], "polars"),
+        (fake_default_index, {"before": 12}, {"like": "c?"}, "arrow"),
+        (sorted_string_index, {"between": ["a", "f"]}, {"like": "c?"}, "polars"),
+        (continuous_datetime_index, ["2021-01-07", "2021-01-20"], None, "arrow"),
+    ],
 )
 def test_polars_arrow_filtering(store, index, rows, cols, astype):
     # Arrange
     original_df = make_table(index, astype=astype)
     index_name = get_index_name(original_df)
-    _, expected = split_table(original_df, rows=rows, cols=cols,
-                              index_name=index_name, keep_index=True)
+    _, expected = split_table(
+        original_df, rows=rows, cols=cols, index_name=index_name, keep_index=True
+    )
     if index == fake_default_index:
         original_df = original_df.drop([DEFAULT_ARROW_INDEX_NAME])
         index_name = None
@@ -25,18 +40,19 @@ def test_polars_arrow_filtering(store, index, rows, cols, astype):
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     # Act
-    table.write(original_df, index=index_name, partition_size=partition_size,
-                warnings='ignore')
+    table.write(
+        original_df, index=index_name, partition_size=partition_size, warnings="ignore"
+    )
     # Assert
     assert_table_equals(table, expected, rows=rows, cols=cols)
 
 
-@pytest.mark.parametrize("astype", ['polars[series]', 'arrow'])
+@pytest.mark.parametrize("astype", ["polars[series]", "arrow"])
 @pytest.mark.parametrize("cols", [1, 3])
 def test_polars_and_arrow_to_pandas(store, astype, cols):
     # Arrange
     original_df = make_table(astype=astype, cols=cols)
-    expected = convert_table(original_df, to='pandas')
+    expected = convert_table(original_df, to="pandas")
 
     index_name = get_index_name(original_df)
     partition_size = get_partition_size(original_df)
@@ -48,14 +64,18 @@ def test_polars_and_arrow_to_pandas(store, astype, cols):
     assert_df_equals(df, expected)
 
 
-@pytest.mark.parametrize(["rows", "cols"],
-                         [(None, None), (None, ['c0']),
-                          ([0, 1, 2], None),
-                          ({'before': [10]}, {'like': 'c?'}),
-                          ])
+@pytest.mark.parametrize(
+    ["rows", "cols"],
+    [
+        (None, None),
+        (None, ["c0"]),
+        ([0, 1, 2], None),
+        ({"before": [10]}, {"like": "c?"}),
+    ],
+)
 def test_polars_series_io(store, rows, cols):
     # Arrange
-    original_df = make_table(cols=1, astype='polars[series]')
+    original_df = make_table(cols=1, astype="polars[series]")
     _, expected = split_table(original_df, rows=rows)
     expected = drop_default_index_if_exists(expected)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-from .fixtures import *
+from .fixtures import DB_PATH
 
 import os
 import shutil
@@ -19,7 +19,7 @@ def test_create():
 
 def test_io(metadata):
     # Arrange
-    items = {f'a{i}': i for i in range(100)}
+    items = {f"a{i}": i for i in range(100)}
     # Act
     metadata.write(items)
     # Assert
@@ -28,9 +28,9 @@ def test_io(metadata):
 
 def test_overwrite(metadata):
     # Arrange
-    items = {f'a{i}': i for i in range(100)}
+    items = {f"a{i}": i for i in range(100)}
     metadata.write(items)
-    new_items = {f'a{i}': str(i) for i in range(100)}
+    new_items = {f"a{i}": str(i) for i in range(100)}
     # Act
     metadata.write(new_items)
     # Assert
@@ -41,10 +41,10 @@ def test_overwrite(metadata):
 def test_init(metadata):
     # Arrange
     SIZE = 100
-    items = {f'a{i}': i for i in range(SIZE)}
+    items = {f"a{i}": i for i in range(SIZE)}
     metadata.write(items)
     # Act
-    metadata = Metadata(DB_PATH, 'db')
+    metadata = Metadata(DB_PATH, "db")
     # Assert
     assert len(metadata) == SIZE
     assert metadata.keys() == sorted(items.keys())
@@ -53,7 +53,7 @@ def test_init(metadata):
 
 def test_keys(metadata):
     # Arrange
-    items = {f'a{i}': i for i in range(20)}
+    items = {f"a{i}": i for i in range(20)}
     metadata.write(items)
     # Act and Assert
     assert metadata.keys() == sorted(items.keys())
@@ -61,8 +61,8 @@ def test_keys(metadata):
 
 def test_getitem(metadata):
     # Arrange
-    KEY = 'a3'
-    items = {f'a{i}': i for i in range(5)}
+    KEY = "a3"
+    items = {f"a{i}": i for i in range(5)}
     metadata.write(items)
     # Act and Assert
     assert metadata[KEY] == items[KEY]
@@ -70,8 +70,8 @@ def test_getitem(metadata):
 
 def test_setitem(metadata):
     # Arrange
-    KEY = 'a3'
-    items = {f'a{i}': i for i in range(5)}
+    KEY = "a3"
+    items = {f"a{i}": i for i in range(5)}
     metadata.write(items)
     # Act
     metadata[KEY] = 1000
@@ -81,8 +81,8 @@ def test_setitem(metadata):
 
 def test_delitem(metadata):
     # Arrange
-    KEY = 'a3'
-    items = {f'a{i}': i for i in range(5)}
+    KEY = "a3"
+    items = {f"a{i}": i for i in range(5)}
     metadata.write(items)
     # Act
     del metadata[KEY]
@@ -92,8 +92,8 @@ def test_delitem(metadata):
 
 def test_compact(metadata):
     SIZE = 10
-    items = {f'a{i}': i for i in range(SIZE)}
-    new_items = {f'a{i}': None for i in range(SIZE + 1)}
+    items = {f"a{i}": i for i in range(SIZE)}
+    new_items = {f"a{i}": None for i in range(SIZE + 1)}
 
     metadata.write(items)
     # Act

--- a/tests/test_rename_cols.py
+++ b/tests/test_rename_cols.py
@@ -1,13 +1,19 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DEFAULT_ARROW_INDEX_NAME,
+    TABLE_NAME,
+    assert_table_equals,
+    get_partition_size,
+    make_table,
+)
 
 
 @pytest.mark.parametrize(
     ("columns", "to", "result"),
     [
-        (['c0', 'c2'], ['d0', 'like'], ['d0', 'c1', 'like', 'c3']),
-        ({'c0': 'd0', 'c2': 'like'}, None, ['d0', 'c1', 'like', 'c3']),
-        (['c2', 'c3'], ['c3', 'c2'], ['c0', 'c1', 'c3', 'c2'])
+        (["c0", "c2"], ["d0", "like"], ["d0", "c1", "like", "c3"]),
+        ({"c0": "d0", "c2": "like"}, None, ["d0", "c1", "like", "c3"]),
+        (["c2", "c3"], ["c3", "c2"], ["c0", "c1", "c3", "c2"]),
     ],
 )
 def test_rename_cols(store, columns, to, result):
@@ -18,23 +24,23 @@ def test_rename_cols(store, columns, to, result):
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
-    table.write(original_df, partition_size=partition_size, warnings='ignore')
+    table.write(original_df, partition_size=partition_size, warnings="ignore")
     # Act
     table.rename_columns(columns, to=to)
     # Assert
     assert_table_equals(table, expected)
 
 
-NEW_COL_NAMES_PROVIDED_TWICE = [{'c0': 'd0'}, ['d0']]
-NEW_NAMES_NOT_PROVIDED = [['c0', 'c1'], None]
-NUMBER_OF_COLS_DOESNT_MATCH = [['c0', 'c1'], ['d0']]
-INVALID_OLD_COLS_ARGUMENT_DTYPE = [[1], ['d0']]
-INVALID_NEW_COLS_ARGUMENT_DTYPE = [['c0'], [1]]
-INVALID_COLS_KEYS_ARGUMENT_DTYPE = [{0: 'd0'}, None]
-INVALID_COLS_VALUES_ARGUMENT_DTYPE = [{'c0': 1}, None]
-DUPLICATE_COL_NAMES = [['c0', 'c1'], ['d0', 'd0']]
-COL_NAME_ALREADY_IN_TABLE = [{'c0': 'c1'}, None]
-RENAME_COL_TO_INDEX_NAME = [{'c0': DEFAULT_ARROW_INDEX_NAME}, None]
+NEW_COL_NAMES_PROVIDED_TWICE = [{"c0": "d0"}, ["d0"]]
+NEW_NAMES_NOT_PROVIDED = [["c0", "c1"], None]
+NUMBER_OF_COLS_DOESNT_MATCH = [["c0", "c1"], ["d0"]]
+INVALID_OLD_COLS_ARGUMENT_DTYPE = [[1], ["d0"]]
+INVALID_NEW_COLS_ARGUMENT_DTYPE = [["c0"], [1]]
+INVALID_COLS_KEYS_ARGUMENT_DTYPE = [{0: "d0"}, None]
+INVALID_COLS_VALUES_ARGUMENT_DTYPE = [{"c0": 1}, None]
+DUPLICATE_COL_NAMES = [["c0", "c1"], ["d0", "d0"]]
+COL_NAME_ALREADY_IN_TABLE = [{"c0": "c1"}, None]
+RENAME_COL_TO_INDEX_NAME = [{"c0": DEFAULT_ARROW_INDEX_NAME}, None]
 
 
 @pytest.mark.parametrize(
@@ -62,12 +68,12 @@ RENAME_COL_TO_INDEX_NAME = [{'c0': DEFAULT_ARROW_INDEX_NAME}, None]
         "DUPLICATE_COL_NAMES",
         "COL_NAME_ALREADY_IN_TABLE",
         "RENAME_COL_TO_INDEX_NAME",
-    ]
+    ],
 )
 def test_can_rename_cols(store, args, exception):
     # Arrange
     col_names, new_col_names = args
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_reorder_cols.py
+++ b/tests/test_reorder_cols.py
@@ -1,12 +1,17 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DEFAULT_ARROW_INDEX_NAME,
+    TABLE_NAME,
+    assert_table_equals,
+    make_table,
+)
 
 
 @pytest.mark.parametrize("use_property", [True, False])
 def test_reorder_columns(store, use_property):
     # Arrange
     COLS = ["c1", "c0", "c2", "c4", "c3"]
-    original_df = make_table(astype='pandas')
+    original_df = make_table(astype="pandas")
     expected = original_df[COLS]
 
     table = store.select_table(TABLE_NAME)
@@ -20,12 +25,12 @@ def test_reorder_columns(store, use_property):
     assert_table_equals(table, expected)
 
 
-COLS_NOT_IN_TABLE = ['c0', 'c2', 'd1']
-NUMBER_OF_COLS_DOESNT_MATCH = ['c1', 'c0']
-INDEX_IS_PROVIDED = [DEFAULT_ARROW_INDEX_NAME, 'c0', 'c1']
-CONTAINS_DUPLICATES = ['c0', 'c1', 'c1']
-INVALID_DTYPE = {'c1', 'c0', 'c2'}
-INVALID_ELEMENTS_DTYPE = [1, 'c0', 'c2']
+COLS_NOT_IN_TABLE = ["c0", "c2", "d1"]
+NUMBER_OF_COLS_DOESNT_MATCH = ["c1", "c0"]
+INDEX_IS_PROVIDED = [DEFAULT_ARROW_INDEX_NAME, "c0", "c1"]
+CONTAINS_DUPLICATES = ["c0", "c1", "c1"]
+INVALID_DTYPE = {"c1", "c0", "c2"}
+INVALID_ELEMENTS_DTYPE = [1, "c0", "c2"]
 
 
 @pytest.mark.parametrize(
@@ -49,7 +54,7 @@ INVALID_ELEMENTS_DTYPE = [1, 'c0', 'c2']
 )
 def test_can_reorder_columns(store, cols, exception):
     # Arrange
-    original_df = make_table(cols=3, astype='pandas')
+    original_df = make_table(cols=3, astype="pandas")
     table = store.select_table(TABLE_NAME)
     table.write(original_df)
     # Act and Assert

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,15 +1,23 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    DB_PATH,
+    STORE_NAME,
+    TABLE_NAME,
+    assert_df_equals,
+    assert_table_equals,
+    get_partition_size,
+    make_table,
+)
 
 import os
 import featherstore as fs
 
-SNAPSHOT_PATH = os.path.join(DB_PATH, 'table_snapshot.tar.xz')
+SNAPSHOT_PATH = os.path.join(DB_PATH, "table_snapshot.tar.xz")
 
 
 def test_table_snapshot(store):
     # Arrange
-    original_df = make_table(astype='pandas')
+    original_df = make_table(astype="pandas")
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
     table.write(original_df, partition_size=partition_size)
@@ -27,18 +35,18 @@ def test_table_snapshot(store):
 def test_store_snapshot(store):
     # Arrange
     store_name = store.name
-    original_df1 = make_table(astype='pandas')
-    original_df2 = make_table(astype='pandas')
+    original_df1 = make_table(astype="pandas")
+    original_df2 = make_table(astype="pandas")
 
     partition_size = get_partition_size(original_df1)
-    store.write_table('df1', original_df1, partition_size=partition_size)
-    store.write_table('df2', original_df2, partition_size=partition_size)
+    store.write_table("df1", original_df1, partition_size=partition_size)
+    store.write_table("df2", original_df2, partition_size=partition_size)
     # Act
     store.create_snapshot(SNAPSHOT_PATH)
-    store.rename(to=f'{store_name}2')
+    store.rename(to=f"{store_name}2")
     fs.snapshot.restore_store(SNAPSHOT_PATH)
     # Assert
-    _assert_store_equal(store_name, f'{store_name}2')
+    _assert_store_equal(store_name, f"{store_name}2")
     # Teardown
     os.remove(SNAPSHOT_PATH)
 
@@ -57,7 +65,7 @@ def _assert_store_equal(store_name1, store_name2):
 
 def test_that_restoring_snapshot_cannot_overwrite_existing_table(store):
     # Arrange
-    original_df = make_table(astype='pandas')
+    original_df = make_table(astype="pandas")
 
     partition_size = get_partition_size(original_df)
     table = store.select_table(TABLE_NAME)
@@ -70,7 +78,7 @@ def test_that_restoring_snapshot_cannot_overwrite_existing_table(store):
 
 
 def test_that_restoring_snapshot_cannot_overwrite_existing_store(store):
-    original_df = make_table(astype='pandas')
+    original_df = make_table(astype="pandas")
 
     partition_size = get_partition_size(original_df)
     store.write_table(TABLE_NAME, original_df, partition_size=partition_size)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,17 @@
 import pytest
-from .fixtures import *
+from .fixtures import (
+    TABLE_NAME,
+    assert_df_equals,
+    assert_table_equals,
+    continuous_datetime_index,
+    continuous_string_index,
+    default_index,
+    get_partition_size,
+    make_table,
+    sorted_string_index,
+    split_table,
+    update_values,
+)
 
 import warnings
 import pandas as pd
@@ -8,12 +20,17 @@ import pandas as pd
 @pytest.mark.parametrize(
     ["index", "rows", "cols", "num_cols"],
     [
-        (default_index, [10, 13, 14, 21], ['c1', 'c3', 'c2'], 5),
-        (default_index, None, ['c1', 'c3', 'c2'], 5),
-        (default_index, None, ['c0'], 3),
-        (continuous_string_index, ["al", "aj", "ba", "af"], ['c0'], 1),
-        (continuous_datetime_index, ["2021-01-01", "2021-01-16", "2021-01-07"], ['c0'], 1)
-    ]
+        (default_index, [10, 13, 14, 21], ["c1", "c3", "c2"], 5),
+        (default_index, None, ["c1", "c3", "c2"], 5),
+        (default_index, None, ["c0"], 3),
+        (continuous_string_index, ["al", "aj", "ba", "af"], ["c0"], 1),
+        (
+            continuous_datetime_index,
+            ["2021-01-01", "2021-01-16", "2021-01-07"],
+            ["c0"],
+            1,
+        ),
+    ],
 )
 def test_update_table(store, index, rows, cols, num_cols):
     # Arrange
@@ -49,9 +66,9 @@ def update_table(df, update_df):
 @pytest.mark.parametrize(["num_partitions", "rows"], [(7, 30), (3, 125), (27, 36)])
 def test_partition_structure_after_update_table(store, num_partitions, rows):
     # Arrange
-    original_df = make_table(rows=rows, astype='pandas')
-    original_df.index.name = 'index'
-    _, update_df = split_table(original_df, rows=(10, 13, 14, 21), cols=['c2', 'c0'])
+    original_df = make_table(rows=rows, astype="pandas")
+    original_df.index.name = "index"
+    _, update_df = split_table(original_df, rows=(10, 13, 14, 21), cols=["c2", "c0"])
     update_df = update_values(update_df)
     expected = update_table(original_df, update_df)
 
@@ -71,7 +88,7 @@ def test_partition_structure_after_update_table(store, num_partitions, rows):
 def _assert_that_partitions_are_the_same(table, partition_names, partition_data):
     # Check that partitions keep the same structure after update
     df = table.read_arrow()
-    index = df['index']
+    index = df["index"]
     for partition, partition_name in zip(index.chunks, partition_names):
         metadata = partition_data[partition_name]
 
@@ -79,9 +96,9 @@ def _assert_that_partitions_are_the_same(table, partition_names, partition_data)
         index_end = partition[-1].as_py()
         num_rows = len(partition)
 
-        assert index_start == metadata['min']
-        assert index_end == metadata['max']
-        assert num_rows == metadata['num_rows']
+        assert index_start == metadata["min"]
+        assert index_end == metadata["max"]
+        assert num_rows == metadata["num_rows"]
 
 
 def _update_table_not_pd_table():
@@ -97,7 +114,7 @@ def _non_matching_index_dtype():
 def _non_matching_column_dtypes():
     df = make_table(sorted_string_index, cols=1, astype="pandas")
     df = df.reset_index()
-    df.columns = ['c1', 'c2']
+    df.columns = ["c1", "c2"]
     df = df.head(5)
     return df
 
@@ -112,14 +129,14 @@ def _index_not_in_table():
 def _column_name_not_in_stored_data():
     df = make_table(cols=2, astype="pandas")
     df = df.head(5)
-    df.columns = ['c1', 'non-existant_column']
+    df.columns = ["c1", "non-existant_column"]
     return df
 
 
 def _index_name_not_the_same_as_stored_index():
     df = make_table(astype="pandas")
     df = df.head(5)
-    df.index.name = 'new_index_name'
+    df.index.name = "new_index_name"
     return df
 
 
@@ -133,7 +150,7 @@ def _duplicate_index_values():
 def _duplicate_column_names():
     df = make_table(cols=2, astype="pandas")
     df = df.head(5)
-    df.columns = ['c2', 'c2']
+    df.columns = ["c2", "c2"]
     return df
 
 
@@ -163,7 +180,7 @@ def _duplicate_column_names():
 def test_can_update_table(store, update_df, exception):
     # Arrange
     update_df = update_df()
-    original_df = make_table(cols=5, astype='pandas')
+    original_df = make_table(cols=5, astype="pandas")
     store.write_table(TABLE_NAME, original_df)
     table = store.select_table(TABLE_NAME)
     # Act


### PR DESCRIPTION
## Summary
- Replace all `from .fixtures import *` star imports with explicit imports and add `__all__` to the fixtures package
- Apply ruff formatting across `featherstore`, `tests`, and `benchmarks`; fix remaining flake8 violations (E303, E501, W503) and ignore E203 for ruff-compatible slice spacing
- Broaden index type validation in `_table_utils` and `_raise_if` (decimal, float, uint, binary, duration, and more)
- Add new test fixtures and an e2e workflow test for astype, expected-table, and hardcoded-table scenarios
- Raise minimum Polars version to **1.21.0** (first release with `n_unique()` support for decimal index dtypes; fixes Ubuntu CI failure)

## Dependency change
Polars 1.21.0 ([release notes](https://github.com/pola-rs/polars/releases/tag/py-1.21.0), [PR #20855](https://github.com/pola-rs/polars/pull/20855)) added unique/n_unique operations for Decimal dtype. The previous floor of 1.0.0 caused `test_basic_io_with_exotic_indices[sorted_decimal_index-pandas[series]]` to fail in Ubuntu CI because duplicate-index checking calls `Series.n_unique()` on decimal indices.

## Test plan
- [x] `uv run ruff check featherstore tests benchmarks`
- [x] `uv run ruff format --check featherstore tests benchmarks`
- [x] `uv run flake8 featherstore tests --exclude=.venv,.dev,build,dist,benchmarks`
- [x] `uv run pytest tests -m 'not integration and not e2e'` (355 passed)
- [x] Ubuntu CI with `polars[timezone]==1.21.0`