### PR TITLE
Dry up duplicated can_* validation sequences

### DIFF
--- a/featherstore/_table/_raise_if.py
+++ b/featherstore/_table/_raise_if.py
@@ -7,8 +7,9 @@ import polars as pl
 import pyarrow as pa
 
 from featherstore._metadata import METADATA_FOLDER_NAME
-from featherstore._table import _table_utils
-from featherstore._table._indexers import ColIndexer
+from featherstore._table import _table_utils, common
+from featherstore._table._indexers import ColIndexer, RowIndexer
+from featherstore.connection import Connection
 from featherstore.exceptions import (
     ColumnMismatchError,
     ColumnNotFoundError,
@@ -339,3 +340,47 @@ def index_values_contains_duplicates(index):
         contains_duplicates = index.n_unique() < index.shape[0]
         if contains_duplicates:
             raise DuplicateIndexValuesError("Index values must be unique")
+
+
+def not_connected():
+    Connection._raise_if_not_connected()
+
+
+def not_connected_or_table_not_exists(table):
+    not_connected()
+    table_not_exists(table)
+
+
+def df_index_or_column_names_incompatible_with_stored(
+    df, table_data, cols, *, index=None, check_index_values=True
+):
+    index_name_not_same_as_stored_index(df, table_data)
+    col_names_contains_duplicates(cols)
+    index_type_not_same_as_stored_index(df, table_data)
+    if check_index_values:
+        if index is None:
+            index = df.index
+        index_values_contains_duplicates(index)
+
+
+def rows_argument_is_not_valid(rows, table_data, *, allow_none=False):
+    if allow_none:
+        rows_argument_is_not_collection_or_none(rows)
+    else:
+        rows_argument_is_not_collection(rows)
+
+    rows = RowIndexer(rows)
+    rows_items_not_all_same_type(rows)
+    rows_argument_items_type_not_same_as_index(rows, table_data)
+    return rows
+
+
+def cols_and_to_arguments_are_not_valid(cols, to):
+    cols_argument_is_not_collection(cols)
+    to_is_provided_twice(cols, to)
+    to_not_provided(cols, to)
+
+    if not isinstance(cols, dict):
+        to_argument_is_not_list_like(to)
+        length_of_cols_and_to_doesnt_match(cols, to)
+    return common.format_cols_and_to_args(cols, to)

--- a/featherstore/_table/_table_utils.py
+++ b/featherstore/_table/_table_utils.py
@@ -71,6 +71,12 @@ def get_col_names(df, has_default_index):
     return cols
 
 
+def get_pandas_column_names(df):
+    if isinstance(df, pd.Series):
+        return [df.name]
+    return df.columns.tolist()
+
+
 def convert_to_arrow(df, as_array=False):
     if isinstance(df, (pl.Series, pd.Series, pd.Index)):
         if as_array:

--- a/featherstore/_table/append.py
+++ b/featherstore/_table/append.py
@@ -3,22 +3,20 @@ import pyarrow as pa
 from featherstore import _utils
 from featherstore._table import _raise_if, _table_utils, common
 from featherstore._utils import DEFAULT_ARROW_INDEX_NAME
-from featherstore.connection import Connection
 from featherstore.exceptions import AppendIndexError, MissingIndexError
 
 
 def can_append_table(table, df, warnings):
-    Connection._raise_if_not_connected()
+    _raise_if.not_connected_or_table_not_exists(table)
     _utils.raise_if_warnings_argument_is_not_valid(warnings)
 
-    _raise_if.table_not_exists(table)
     _raise_if.df_is_not_supported_table_type(df)
 
     table_data = table._table_data
     cols = _table_utils.get_col_names(df, has_default_index=False)
-    _raise_if.index_name_not_same_as_stored_index(df, table_data)
-    _raise_if.col_names_contains_duplicates(cols)
-    _raise_if.index_type_not_same_as_stored_index(df, table_data)
+    _raise_if.df_index_or_column_names_incompatible_with_stored(
+        df, table_data, cols, check_index_values=False
+    )
     _raise_if.cols_does_not_match(df, table_data)
 
     has_default_index = table_data["has_default_index"]

--- a/featherstore/_table/astype.py
+++ b/featherstore/_table/astype.py
@@ -1,21 +1,12 @@
 import pyarrow as pa
 
-from featherstore._table import _raise_if, _table_utils, common
-from featherstore.connection import Connection
+from featherstore._table import _raise_if, _table_utils
 
 
 def can_change_type(table, cols, astype):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
 
-    _raise_if.cols_argument_is_not_collection(cols)
-    _raise_if.to_is_provided_twice(cols, astype)
-    _raise_if.to_not_provided(cols, astype)
-
-    if not isinstance(cols, dict):
-        _raise_if.to_argument_is_not_list_like(astype)
-        _raise_if.length_of_cols_and_to_doesnt_match(cols, astype)
-    cols = common.format_cols_and_to_args(cols, astype)
+    cols = _raise_if.cols_and_to_arguments_are_not_valid(cols, astype)
 
     _raise_if.cols_argument_items_is_not_str_or_none(cols.keys())
     _raise_if_astype_items_are_not_pa_or_np_types(cols.values())

--- a/featherstore/_table/drop.py
+++ b/featherstore/_table/drop.py
@@ -6,9 +6,8 @@ import pyarrow as pa
 
 from featherstore import _utils
 from featherstore._table import _raise_if, _table_utils
-from featherstore._table._indexers import ColIndexer, RowIndexer
+from featherstore._table._indexers import ColIndexer
 from featherstore._table.read import get_partition_names as _get_partition_names
-from featherstore.connection import Connection
 from featherstore.exceptions import (
     CannotDropAllColumnsError,
     CannotDropAllRowsError,
@@ -17,13 +16,8 @@ from featherstore.exceptions import (
 
 
 def can_drop_rows_from_table(table, rows):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
-    _raise_if.rows_argument_is_not_collection(rows)
-
-    rows = RowIndexer(rows)
-    _raise_if.rows_items_not_all_same_type(rows)
-    _raise_if.rows_argument_items_type_not_same_as_index(rows, table._table_data)
+    _raise_if.not_connected_or_table_not_exists(table)
+    _raise_if.rows_argument_is_not_valid(rows, table._table_data)
 
 
 def get_partition_names(table, rows):
@@ -154,8 +148,7 @@ def _idx_still_default_after_dropping_rows_list(rows, partition_metadata):
 
 
 def can_drop_cols_from_table(table, cols):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
     _raise_if.cols_argument_is_not_collection(cols)
 
     raise_if = CheckDropCols(cols, table)

--- a/featherstore/_table/insert_cols.py
+++ b/featherstore/_table/insert_cols.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from featherstore._table import _raise_if, _table_utils
 from featherstore._table._indexers import ColIndexer
-from featherstore.connection import Connection
 from featherstore.exceptions import (
     ColumnAlreadyExistsError,
     ColumnLengthMismatchError,
@@ -13,15 +12,10 @@ from featherstore.exceptions import (
 
 
 def can_insert_columns(table, df, idx=-1):
-    Connection._raise_if_not_connected()
-
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
     _raise_if.df_is_not_pandas_table(df)
 
-    if isinstance(df, pd.Series):
-        cols = [df.name]
-    else:
-        cols = df.columns.tolist()
+    cols = _table_utils.get_pandas_column_names(df)
     _raise_if.col_names_contains_duplicates(cols)
     _raise_if.index_in_cols(cols, table._table_data)
     _raise_if_col_name_already_in_table(cols, table._table_data)

--- a/featherstore/_table/insert_rows.py
+++ b/featherstore/_table/insert_rows.py
@@ -1,28 +1,19 @@
 import itertools
 
-import pandas as pd
 import pyarrow as pa
 
 from featherstore._table import _raise_if, _table_utils
-from featherstore.connection import Connection
 from featherstore.exceptions import RowAlreadyExistsError
 
 
 def can_insert_rows(table, df):
-    Connection._raise_if_not_connected()
-
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
     _raise_if.df_is_not_pandas_table(df)
 
-    if isinstance(df, pd.Series):
-        cols = [df.name]
-    else:
-        cols = df.columns.tolist()
-
-    _raise_if.index_name_not_same_as_stored_index(df, table._table_data)
-    _raise_if.col_names_contains_duplicates(cols)
-    _raise_if.index_values_contains_duplicates(df.index)
-    _raise_if.index_type_not_same_as_stored_index(df, table._table_data)
+    cols = _table_utils.get_pandas_column_names(df)
+    _raise_if.df_index_or_column_names_incompatible_with_stored(
+        df, table._table_data, cols
+    )
     _raise_if.cols_does_not_match(df, table._table_data)
 
 

--- a/featherstore/_table/misc.py
+++ b/featherstore/_table/misc.py
@@ -1,11 +1,10 @@
 from featherstore import store
 from featherstore._table import _raise_if
-from featherstore.connection import Connection
 from featherstore.exceptions import ColumnMismatchError
 
 
 def can_init_table(table_name, store_name):
-    Connection._raise_if_not_connected()
+    _raise_if.not_connected()
     store._raise_if_store_name_is_str(store_name)
     store._raise_if_store_not_exists(store_name)
 
@@ -14,7 +13,7 @@ def can_init_table(table_name, store_name):
 
 
 def can_rename_table(new_table_name, new_table_path):
-    Connection._raise_if_not_connected()
+    _raise_if.not_connected()
 
     _raise_if.table_name_is_not_str(new_table_name)
     _raise_if.table_name_is_forbidden(new_table_path)
@@ -22,8 +21,7 @@ def can_rename_table(new_table_name, new_table_path):
 
 
 def can_reorder_columns(table, cols):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
 
     _raise_if.cols_argument_is_not_list_like(cols)
     _raise_if.cols_argument_items_is_not_str_or_none(cols)

--- a/featherstore/_table/read.py
+++ b/featherstore/_table/read.py
@@ -9,19 +9,14 @@ from pyarrow import ipc
 from featherstore._metadata import Metadata
 from featherstore._table import _raise_if, _table_utils
 from featherstore._table._indexers import ColIndexer, RowIndexer
-from featherstore.connection import Connection
 
 
 def can_read_table(table, cols, rows, mmap):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
 
     _raise_if_mmap_is_not_bool_or_none(mmap)
 
-    _raise_if.rows_argument_is_not_collection_or_none(rows)
-    rows = RowIndexer(rows)
-    _raise_if.rows_items_not_all_same_type(rows)
-    _raise_if.rows_argument_items_type_not_same_as_index(rows, table._table_data)
+    _raise_if.rows_argument_is_not_valid(rows, table._table_data, allow_none=True)
 
     _raise_if.cols_argument_is_not_collection_or_none(cols)
     cols = ColIndexer(cols)

--- a/featherstore/_table/rename_cols.py
+++ b/featherstore/_table/rename_cols.py
@@ -1,19 +1,10 @@
-from featherstore._table import _raise_if, common
-from featherstore.connection import Connection
+from featherstore._table import _raise_if
 
 
 def can_rename_columns(table, cols, new_col_names):
-    Connection._raise_if_not_connected()
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
 
-    _raise_if.cols_argument_is_not_collection(cols)
-    _raise_if.to_is_provided_twice(cols, new_col_names)
-    _raise_if.to_not_provided(cols, new_col_names)
-
-    if not isinstance(cols, dict):
-        _raise_if.to_argument_is_not_list_like(new_col_names)
-        _raise_if.length_of_cols_and_to_doesnt_match(cols, new_col_names)
-    cols = common.format_cols_and_to_args(cols, new_col_names)
+    cols = _raise_if.cols_and_to_arguments_are_not_valid(cols, new_col_names)
 
     _raise_if.cols_argument_items_is_not_str_or_none(cols.keys())
     _raise_if_new_cols_items_is_not_str(cols.values())

--- a/featherstore/_table/update.py
+++ b/featherstore/_table/update.py
@@ -2,26 +2,18 @@ import warnings
 
 import pandas as pd
 
-from featherstore._table import _raise_if
-from featherstore.connection import Connection
+from featherstore._table import _raise_if, _table_utils
 from featherstore.exceptions import ColumnDtypeMismatchError, RowNotFoundError
 
 
 def can_update_table(table, df):
-    Connection._raise_if_not_connected()
-
-    _raise_if.table_not_exists(table)
+    _raise_if.not_connected_or_table_not_exists(table)
     _raise_if.df_is_not_pandas_table(df)
 
-    if isinstance(df, pd.Series):
-        cols = [df.name]
-    else:
-        cols = df.columns.tolist()
-
-    _raise_if.index_name_not_same_as_stored_index(df, table._table_data)
-    _raise_if.col_names_contains_duplicates(cols)
-    _raise_if.index_type_not_same_as_stored_index(df, table._table_data)
-    _raise_if.index_values_contains_duplicates(df.index)
+    cols = _table_utils.get_pandas_column_names(df)
+    _raise_if.df_index_or_column_names_incompatible_with_stored(
+        df, table._table_data, cols
+    )
     _raise_if.cols_not_in_table(cols, table._table_data)
 
 

--- a/featherstore/_table/write.py
+++ b/featherstore/_table/write.py
@@ -8,12 +8,11 @@ from pyarrow import ipc
 from featherstore import _utils
 from featherstore._table import _raise_if, _table_utils, common
 from featherstore._utils import DEFAULT_ARROW_INDEX_NAME
-from featherstore.connection import Connection
 from featherstore.exceptions import IndexNotInColumnsError
 
 
 def can_write_table(table, df, index_name, partition_size, errors, warnings):
-    Connection._raise_if_not_connected()
+    _raise_if.not_connected()
     _utils.raise_if_errors_argument_is_not_valid(errors)
     _utils.raise_if_warnings_argument_is_not_valid(warnings)
     _raise_if_partition_size_is_not_int(partition_size)


### PR DESCRIPTION
## Summary
- Extract shared `can_*` validation clusters into `_raise_if` helpers (`not_connected`, `not_connected_or_table_not_exists`, `df_index_or_column_names_incompatible_with_stored`, `rows_argument_is_not_valid`, `cols_and_to_arguments_are_not_valid`).
- Move pandas column-name extraction to `_table_utils.get_pandas_column_names`.
- Keep operation-specific rules in each `can_*` function; no public API or exception-message changes.

## Test plan
- [x] `uv run pytest tests/` (374 passed)
- [x] `uv run ruff check featherstore tests`
- [x] `uv run ruff format --check featherstore tests`