### PR TITLE
Dispatch Table.insert on column names; keyword-only idx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,6 @@
 Changelog
 =========
 
-Unreleased
-----------
-
-**Warning**: This update causes API-breaking changes for code that catches
-built-in exceptions from FeatherStore operations:
-
-* Domain errors now raise custom exceptions from
-  ``featherstore.exceptions`` instead of built-in types such as
-  ``IndexError``, ``FileNotFoundError``, ``FileExistsError``, ``ValueError``,
-  ``TypeError``, ``ConnectionError``, ``ConnectionRefusedError``,
-  ``PermissionError``, and ``OSError``
-* Import exception types via ``from featherstore.exceptions import ...``;
-  they are not re-exported from the top-level ``featherstore`` package
-* Argument-shape validation (invalid types, missing parameters) still raises
-  ``TypeError``, ``ValueError``, and ``AttributeError``
-
-Enhancements:
-
-* Added a hierarchical exception tree rooted at ``FeatherStoreException``,
-  with category bases (``TableError``, ``StoreError``, ``ColumnError``,
-  ``RowError``, ``IndexSchemaError``, ``DatabaseConnectionError``,
-  ``SnapshotError``, ``PathError``) and specific leaf exceptions such as
-  ``ColumnNotFoundError``, ``RowNotFoundError``, and
-  ``TableAlreadyExistsError``
-* Improved domain error messages to include offending values where useful
-  (for example, missing column names and row indices)
-* Added ``tests/test_exceptions.py`` for hierarchy and message coverage
-* Added an Exceptions page to the API reference with a nested hierarchy list
-  and per-class documentation
-* Added ``Raises`` sections to public method and function docstrings for
-  ``Table``, ``Store``, ``connection``, and ``snapshot``
-
-Bug fixes:
-
-* Fixed silent data loss on repeated mid-table ``insert_rows`` caused by
-  lossy partition-ID round-trips (fractional IDs collapsed when generating
-  new mid-gap partition names)
-* Fixed ``reorder_columns`` / ``columns`` setter dropping the index name from
-  table metadata
-* Fixed ``rename_table`` allowing the forbidden ``.metadata`` name
-* Fixed snapshot restore with ``errors="ignore"`` leaving orphan partition
-  files or tables behind
-* Fixed ``astype`` not refreshing ``index_dtype`` metadata when casting the
-  index
-* Fixed stale ``num_columns`` / ``shape`` after inserting or dropping columns
-* Fixed ``database_exists`` not expanding ``~`` in paths
-* Fixed ``Indexer.keyword`` raising ``AttributeError`` for non-keyword dict
-  keys
-* Fixed SQL ``LIKE`` patterns treating regex metacharacters as special and
-  crashing on empty patterns
-* Fixed snapshot restore accepting invalid ``errors`` values
-
 0.3.0
 -----
 
@@ -63,6 +11,15 @@ Bug fixes:
   and `pyarrow>=14.0.0` (upper bounds removed)
 * Renamed `Table.insert()` to `Table.insert_rows()` and
   `Table.add_columns()` to `Table.insert_columns()`
+* Domain errors now raise custom exceptions from
+  ``featherstore.exceptions`` instead of built-in types such as
+  ``IndexError``, ``FileNotFoundError``, ``FileExistsError``, ``ValueError``,
+  ``TypeError``, ``ConnectionError``, ``ConnectionRefusedError``,
+  ``PermissionError``, and ``OSError``
+* Import exception types via ``from featherstore.exceptions import ...``;
+  they are not re-exported from the top-level ``featherstore`` package
+* Argument-shape validation (invalid types, missing parameters) still raises
+  ``TypeError``, ``ValueError``, and ``AttributeError``
 
 Enhancements:
 
@@ -103,12 +60,43 @@ Enhancements:
   hardcoded-table scenarios
 * Raised minimum Polars version to 1.21.0 (first release with `n_unique()`
   support for decimal index dtypes)
+* Added a hierarchical exception tree rooted at ``FeatherStoreException``,
+  with category bases (``TableError``, ``StoreError``, ``ColumnError``,
+  ``RowError``, ``IndexSchemaError``, ``DatabaseConnectionError``,
+  ``SnapshotError``, ``PathError``) and specific leaf exceptions such as
+  ``ColumnNotFoundError``, ``RowNotFoundError``, and
+  ``TableAlreadyExistsError``
+* Improved domain error messages to include offending values where useful
+  (for example, missing column names and row indices)
+* Added ``tests/test_exceptions.py`` for hierarchy and message coverage
+* Added an Exceptions page to the API reference with a nested hierarchy list
+  and per-class documentation
+* Added ``Raises`` sections to public method and function docstrings for
+  ``Table``, ``Store``, ``connection``, and ``snapshot``
 
 Bugfixes:
 
 * Fixed intermittent `PermissionError` (WinError 32) on Windows when deleting
   partition files during bulk cleanup (e.g. `drop_table()`); file removal now
   retries `os.remove` instead of shelling out to `del`
+* Fixed silent data loss on repeated mid-table ``insert_rows`` caused by
+  lossy partition-ID round-trips (fractional IDs collapsed when generating
+  new mid-gap partition names)
+* Fixed ``reorder_columns`` / ``columns`` setter dropping the index name from
+  table metadata
+* Fixed ``rename_table`` allowing the forbidden ``.metadata`` name
+* Fixed snapshot restore with ``errors="ignore"`` leaving orphan partition
+  files or tables behind
+* Fixed ``astype`` not refreshing ``index_dtype`` metadata when casting the
+  index
+* Fixed stale ``num_columns`` / ``shape`` after inserting or dropping columns
+* Fixed ``database_exists`` not expanding ``~`` in paths
+* Fixed ``Indexer.keyword`` raising ``AttributeError`` for non-keyword dict
+  keys
+* Fixed SQL ``LIKE`` patterns treating regex metacharacters as special and
+  crashing on empty patterns
+* Fixed snapshot restore accepting invalid ``errors`` values
+
 
 0.2.1
 -----

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ new_dates = pd.date_range("2021-01-06", periods=1)
 df1 = pd.DataFrame(randn(1, 4), index=new_dates, columns=list("ABCD"))
 store.append_table('example_table', df1)
 
->>> # Insert rows or columns via Table.insert() (dispatches on column count)
+>>> # Insert rows or columns via Table.insert() (dispatches on column names)
 table = store.select_table('example_table')
 new_rows = pd.DataFrame(randn(1, 4), index=[pd.Timestamp("2021-01-07")], columns=list("ABCD"))
-table.insert(new_rows)  # same number of columns -> inserts rows
+table.insert(new_rows)  # matching column names -> inserts rows
 
 new_col = pd.DataFrame({'E': randn(7)}, index=table.read_pandas().index)
-table.insert(new_col, idx=4)  # fewer columns -> inserts column at position 4
+table.insert(new_col, idx=4)  # new column name -> inserts column at position 4
 
 >>> # It also supports querying parts of the data
 store.read_pandas('example_table', rows={'after': '2021-01-05'}, cols=['D', 'A'])

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -182,8 +182,8 @@ more features for working with tables.
     >> True
 
 One of those features is ``Table.insert()``, which inserts rows or columns
-depending on the shape of the input data. If the input has the same number of
-columns as the table, rows are inserted; otherwise columns are inserted.
+depending on the column names of the input data. If the input column names
+match the stored table, rows are inserted; otherwise columns are inserted.
 
 You can also call ``Table.insert_rows()`` or ``Table.insert_columns()`` directly
 when you want to be explicit about the operation.
@@ -192,7 +192,7 @@ when you want to be explicit about the operation.
 .. code-block:: python
 
     df2 = pd.DataFrame(randn(2, 2), index=[4, 2], columns=list("AB"))
-    table.insert(df2)  # same number of columns -> inserts rows
+    table.insert(df2)  # matching column names -> inserts rows
     table.read_pandas()
 
     # The data will be inserted into its sorted index position
@@ -204,9 +204,10 @@ when you want to be explicit about the operation.
     5 -0.353684  1.550073
     6  1.275938  1.054702
 
-To add columns, pass data with fewer columns than the table. Use ``idx`` to
-control where the new column(s) are placed. A single integer inserts a block
-of columns at that position; a sequence places each column individually.
+To add columns, pass data whose column names are not already in the table.
+Use ``idx`` to control where the new column(s) are placed. A single integer
+inserts a block of columns at that position; a sequence places each column
+individually.
 
 .. code-block:: python
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,16 +15,16 @@ import os
 import sys
 import warnings
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'FeatherStore'
-copyright = '2021, Håkon Magne Holmen'
-author = 'Håkon Magne Holmen'
+project = "FeatherStore"
+copyright = "2021, Håkon Magne Holmen"
+author = "Håkon Magne Holmen"
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.1'
+release = "0.2.1"
 
 # -- General configuration ---------------------------------------------------
 
@@ -32,26 +32,26 @@ release = '0.2.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autosummary',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
     "sphinx.ext.linkcode",
 ]
 
 autosummary_generate = True
-autoclass_content = 'both'
-autodoc_member_order = 'bysource'
+autoclass_content = "both"
+autodoc_member_order = "bysource"
 # Napoleon settings
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '_templates', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "_templates", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -59,13 +59,13 @@ exclude_patterns = ['_build', '_templates', 'Thumbs.db', '.DS_Store']
 html_show_sourcelink = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-html_favicon = '_static/favicon.ico'
+html_static_path = ["_static"]
+html_favicon = "_static/favicon.ico"
 html_theme_options = {
     "logo": {
         "image_light": "logo-dark.png",
@@ -75,9 +75,9 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/hakonmh/featherstore",
-            "icon": "fa-brands fa-github"
+            "icon": "fa-brands fa-github",
         }
-    ]
+    ],
 }
 
 
@@ -87,10 +87,10 @@ def linkcode_resolve(domain, info):
     Based on pandas equivalent:
     https://github.com/pandas-dev/pandas/blob/main/doc/source/conf.py#L629-L686
     """
-    if domain != 'py':
+    if domain != "py":
         return None
     modname = info["module"]
-    filename = modname.replace('.', '/')
+    filename = modname.replace(".", "/")
     fullname = info["fullname"]
 
     submod = sys.modules.get(modname)

--- a/featherstore/_table/insert.py
+++ b/featherstore/_table/insert.py
@@ -1,0 +1,21 @@
+from featherstore._table import _raise_if
+from featherstore.exceptions import ColumnMismatchError
+
+
+def can_insert(df, table_data, idx):
+    inserting_rows = cols_matches_table_cols(df, table_data)
+    if inserting_rows:
+        _raise_if_idx_provided_when_inserting_rows(idx)
+
+
+def cols_matches_table_cols(df, table_data):
+    try:
+        _raise_if.cols_does_not_match(df, table_data)
+    except ColumnMismatchError:
+        return False
+    return True
+
+
+def _raise_if_idx_provided_when_inserting_rows(idx):
+    if idx is not -1:
+        raise TypeError("'idx' is only valid when inserting columns")

--- a/featherstore/_table/misc.py
+++ b/featherstore/_table/misc.py
@@ -41,11 +41,3 @@ def _raise_if_cols_doesnt_match(cols, table_data):
             "The columns provided doesn't match the columns stored "
             f"(provided={sorted(cols)}, stored={sorted(stored_cols)})"
         )
-
-
-def num_cols_matches_table_cols(data, table_data):
-    num_cols = data.shape[1] if data.ndim == 2 else 1
-    index_name = table_data["index_name"]
-    stored_cols = table_data["columns"]
-    num_table_cols = sum(col != index_name for col in stored_cols)
-    return num_cols == num_table_cols

--- a/featherstore/table.py
+++ b/featherstore/table.py
@@ -7,6 +7,7 @@ from featherstore._table import (
     astype,
     common,
     drop,
+    insert,
     insert_cols,
     insert_rows,
     misc,
@@ -359,10 +360,10 @@ class Table:
 
         write.write_partitions(partitions, self._table_path)
 
-    def insert(self, df, idx=-1):
+    def insert(self, df, *, idx=-1):
         """Insert one or more rows or columns into the current table.
 
-        If ``df`` has the same number of columns as the table, rows are inserted.
+        If ``df`` column names match the stored table, rows are inserted.
         Otherwise, columns are inserted at position ``idx``.
 
         Parameters
@@ -370,15 +371,18 @@ class Table:
         df : Pandas DataFrame or Pandas Series
             The data to be inserted.
         idx : int or Sequence[int], optional
-            The position(s) to insert new column(s). Only used when inserting columns.
-            If a sequence is provided, it must have one position per new column.
-            Default is to add columns to the end.
+            The position(s) to insert new column(s). Only valid when inserting
+            columns. If a sequence is provided, it must have one position per new
+            column. Default is to add columns to the end.
 
         Raises
         ------
+        TypeError
+            If ``idx`` is passed when inserting rows.
         Same exceptions as :meth:`insert_rows` and :meth:`insert_columns`.
         """
-        if misc.num_cols_matches_table_cols(df, self._table_data):
+        insert.can_insert(df, self._table_data, idx)
+        if insert.cols_matches_table_cols(df, self._table_data):
             self.insert_rows(df)
         else:
             self.insert_columns(df, idx=idx)
@@ -442,7 +446,7 @@ class Table:
         write.write_metadata(self, metadata)
         write.write_partitions(partitions, self._table_path)
 
-    def insert_columns(self, df, idx=-1):
+    def insert_columns(self, df, *, idx=-1):
         """Insert one or more columns into the current table.
 
         Parameters

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -9,7 +9,6 @@ from .fixtures import (
     get_partition_size,
     insert_column_names_at,
     make_table,
-    merge_rows,
     sort_table,
     split_table,
     unsorted_int_index,
@@ -106,22 +105,60 @@ def _build_expected_with_col_positions(df, col_names, col_indices):
     return expected
 
 
+def test_insert_adds_columns_when_names_differ(store):
+    # Arrange
+    original_df = make_table(cols=2, astype="pandas")
+    new_cols = make_table(cols=2, astype="pandas")
+    new_cols.columns = ["n0", "n1"]
+    expected = original_df.copy()
+    expected["n0"] = new_cols["n0"]
+    expected["n1"] = new_cols["n1"]
+
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df)
+    # Act
+    table.insert(new_cols)
+    # Assert
+    assert_table_equals(table, expected)
+
+
 @pytest.mark.parametrize("row_indices", ([-2, -1], [30, 33], [33, 30, 32, 31]))
-def test_insert_ignores_idx_when_inserting_rows(store, row_indices):
+def test_insert_raises_when_idx_passed_for_rows(store, row_indices):
     # Arrange
     original_df = make_table(default_index, rows=30, astype="pandas")
     insert_df = make_table(default_index, rows=len(row_indices), astype="pandas")
     insert_df.index = row_indices
 
-    expected = merge_rows(original_df, insert_df, as_arrow=True)
-
     partition_size = get_partition_size(original_df, 5)
     table = store.select_table(TABLE_NAME)
     table.write(original_df, partition_size=partition_size, warnings="ignore")
-    # Act
-    table.insert(insert_df, idx=0)
-    # Assert
-    assert_table_equals(table, expected)
+    # Act and Assert
+    with pytest.raises(TypeError, match="idx"):
+        table.insert(insert_df, idx=0)
+
+
+def test_insert_rejects_positional_idx(store):
+    # Arrange
+    original_df = make_table(cols=2, astype="pandas")
+    new_cols = make_table(cols=1, astype="pandas")
+    new_cols.columns = ["new_c0"]
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df)
+    # Act and Assert
+    with pytest.raises(TypeError):
+        table.insert(new_cols, 0)
+
+
+def test_insert_columns_rejects_positional_idx(store):
+    # Arrange
+    original_df = make_table(cols=2, astype="pandas")
+    new_cols = make_table(cols=1, astype="pandas")
+    new_cols.columns = ["new_c0"]
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df)
+    # Act and Assert
+    with pytest.raises(TypeError):
+        table.insert_columns(new_cols, 0)
 
 
 def _two_new_cols():


### PR DESCRIPTION
## Summary
- Route `Table.insert` by matching column names (not column count), via `_table/insert.py`.
- Make `idx` keyword-only on `insert` / `insert_columns`, and raise `TypeError` when `idx` is passed for row inserts.
- Update README/Quickstart and insert tests for the new behavior.

## Test plan
- [ ] `uv run pytest tests/test_insert.py tests/test_insert_rows.py tests/test_insert_cols.py`
- [ ] Row insert with matching names still works; `idx=...` on rows raises `TypeError`
- [ ] Column insert with new names works (including same width as table); positional `idx` rejected