### PR TITLE
Add partition seam regression tests and partition inspection helpers

### DIFF
--- a/featherstore/_table/misc.py
+++ b/featherstore/_table/misc.py
@@ -1,4 +1,6 @@
-from featherstore import store
+import warnings as _warnings
+
+from featherstore import _utils, store
 from featherstore._table import _raise_if
 
 
@@ -17,6 +19,12 @@ def can_rename_table(new_table_name, new_table_path):
     _raise_if.table_name_is_not_str(new_table_name)
     _raise_if.table_name_is_forbidden(new_table_name)
     _raise_if.table_already_exists(new_table_path)
+
+
+def can_drop_table(table, warnings):
+    _utils.raise_if_warnings_argument_is_not_valid(warnings)
+    if not table.exists() and warnings == "warn":
+        _warnings.warn(f"Table '{table.name}' not found")
 
 
 def can_reorder_columns(table, cols):

--- a/featherstore/snapshot.py
+++ b/featherstore/snapshot.py
@@ -17,7 +17,7 @@ from featherstore.exceptions import (
 METADATA_FILE_NAME = "metadata.pkl"
 
 
-def restore_table(store_name, source, errors="raise"):
+def restore_table(store_name, source, *, errors="raise"):
     """Restores a table in to the currently selected db.
 
     Parameters
@@ -59,7 +59,7 @@ def restore_table(store_name, source, errors="raise"):
     return table_name
 
 
-def restore_store(source, errors="raise"):
+def restore_store(source, *, errors="raise"):
     """Restores a store in to the currently selected db.
 
     Parameters

--- a/featherstore/store.py
+++ b/featherstore/store.py
@@ -1,4 +1,5 @@
 import os
+import warnings as _warnings
 
 from featherstore import _utils
 from featherstore._utils import DB_MARKER_NAME
@@ -13,17 +14,17 @@ from featherstore.snapshot import _create_snapshot
 from featherstore.table import DEFAULT_PARTITION_SIZE, Table
 
 
-def create_store(store_name, *, errors="raise"):
+def create_store(store_name, *, warnings="warn"):
     """Creates a new store.
 
     Parameters
     ----------
     store_name : str
         The name of the store to be created
-    errors : str, optional
-        Whether or not to raise an error if the store already exist. Can be either
-        `raise` or `ignore`, `ignore` passes if the store already exists, by
-        default `raise`
+    warnings : str, optional
+        Whether or not to warn if the store already exist. Can be either
+        `warn` or `ignore`, `ignore` passes silently if the store already
+        exists, by default `warn`
 
     Returns
     -------
@@ -33,20 +34,17 @@ def create_store(store_name, *, errors="raise"):
     ------
     NotConnectedError
         If FeatherStore is not connected to a database.
-    StoreAlreadyExistsError
-        If ``errors='raise'`` and the store already exists.
     ForbiddenStoreNameError
         If ``store_name`` is reserved.
     TypeError
         If ``store_name`` is not a str.
     ValueError
-        If ``errors`` is not ``'raise'`` or ``'ignore'``.
+        If ``warnings`` is not ``'warn'`` or ``'ignore'``.
     """
-    _can_create_store(store_name, errors)
+    _can_create_store(store_name, warnings)
 
     store_path = os.path.join(current_db(), store_name)
-    store_already_exists = os.path.exists(store_path)
-    if not store_already_exists:
+    if not os.path.exists(store_path):
         os.mkdir(store_path)
     return Store(store_name)
 
@@ -77,7 +75,7 @@ def rename_store(store_name, *, to):
     Store(store_name).rename(to=to)
 
 
-def drop_store(store_name, *, errors="raise"):
+def drop_store(store_name, *, warnings="warn"):
     """Deletes a store
 
     *Warning*: You can not delete a store containing tables. All tables must
@@ -87,26 +85,25 @@ def drop_store(store_name, *, errors="raise"):
     ----------
     store_name : str
         The name of the store to be deleted
-    errors : str, optional
-        Whether or not to raise an error if the store doesn't exist. Can be either
-        `raise` or `ignore`, by default `raise`
+    warnings : str, optional
+        Whether or not to warn if the store doesn't exist. Can be either
+        `warn` or `ignore`, by default `warn`
 
     Raises
     ------
     NotConnectedError
         If FeatherStore is not connected to a database.
-    StoreNotFoundError
-        If ``errors='raise'`` and the store does not exist.
     StoreNotEmptyError
         If the store still contains tables.
     TypeError
         If ``store_name`` is not a str.
     ValueError
-        If ``errors`` is not ``'raise'`` or ``'ignore'``.
+        If ``warnings`` is not ``'warn'`` or ``'ignore'``.
     """
-    _can_drop_store(store_name, errors)
+    _can_drop_store(store_name, warnings)
     store_path = os.path.join(current_db(), store_name)
-    _utils.delete_folder_tree(store_path, current_db())
+    if os.path.exists(store_path):
+        _utils.delete_folder_tree(store_path, current_db())
 
 
 def list_stores(*, like=None):
@@ -202,7 +199,7 @@ class Store:
         self.name = new_store_name
         self._store_path = new_path
 
-    def drop(self, *, errors="raise"):
+    def drop(self, *, warnings="warn"):
         """Deletes the current store
 
         *Warning*: You can not delete a store containing tables. All tables must
@@ -210,11 +207,11 @@ class Store:
 
         Parameters
         ----------
-        errors : str, optional
-            Whether or not to raise an error if the store doesn't exist. Can be either
-            `raise` or `ignore`, by default `raise`
+        warnings : str, optional
+            Whether or not to warn if the store doesn't exist. Can be either
+            `warn` or `ignore`, by default `warn`
         """
-        drop_store(self.name, errors=errors)
+        drop_store(self.name, warnings=warnings)
 
     def list_tables(self, *, like=None):
         """Lists tables in store
@@ -447,7 +444,7 @@ class Store:
             partition_size=partition_size,
         )
 
-    def append_table(self, table_name, df, warnings="warn"):
+    def append_table(self, table_name, df, *, warnings="warn"):
         """Appends data to a table
 
         Parameters
@@ -518,15 +515,18 @@ class Store:
         """
         Table(table_name, self.name).rename_table(to=to)
 
-    def drop_table(self, table_name):
+    def drop_table(self, table_name, *, warnings="warn"):
         """Deletes a table
 
         Parameters
         ----------
         table_name : str
             The name of the table to be deleted
+        warnings : str, optional
+            Whether or not to warn if the table doesn't exist. Can be either
+            `warn` or `ignore`, by default `warn`
         """
-        Table(table_name, self.name).drop_table()
+        Table(table_name, self.name).drop_table(warnings=warnings)
 
     def select_table(self, table_name):
         """Selects a single table.
@@ -566,20 +566,22 @@ class Store:
         _create_snapshot(path, self._store_path, "store")
 
 
-def _can_create_store(store_name, errors):
+def _can_create_store(store_name, warnings):
     Connection._raise_if_not_connected()
-    _utils.raise_if_errors_argument_is_not_valid(errors)
-    if errors == "raise":
-        _raise_if_store_already_exists(store_name)
+    _utils.raise_if_warnings_argument_is_not_valid(warnings)
     _raise_if_store_name_is_forbidden(store_name)
+    store_path = os.path.join(current_db(), store_name)
+    if os.path.exists(store_path) and warnings == "warn":
+        _warnings.warn(f"A store with name {store_name} already exists")
 
 
-def _can_drop_store(store_name, errors):
+def _can_drop_store(store_name, warnings):
     Connection._raise_if_not_connected()
-    _utils.raise_if_errors_argument_is_not_valid(errors)
-    if errors == "raise":
-        _raise_if_store_not_exists(store_name)
+    _utils.raise_if_warnings_argument_is_not_valid(warnings)
     _raise_if_store_contains_tables(store_name)
+    store_path = os.path.join(current_db(), store_name)
+    if not os.path.exists(store_path) and warnings == "warn":
+        _warnings.warn(f"Store doesn't exist: '{store_name}'")
 
 
 def _raise_if_store_contains_tables(store_name):

--- a/featherstore/table.py
+++ b/featherstore/table.py
@@ -237,7 +237,7 @@ class Table:
         metadata = write.generate_metadata(
             partitions, partition_size, rows_per_partition
         )
-        self.drop_table()
+        self.drop_table(warnings="ignore")
         self._create_table()
         write.write_metadata(self, metadata)
         write.write_partitions(partitions, self._table_path)
@@ -861,8 +861,21 @@ class Table:
         os.rename(self._table_path, new_path)
         self._table_path = new_path
 
-    def drop_table(self):
-        """Deletes the current table"""
+    def drop_table(self, *, warnings="warn"):
+        """Deletes the current table
+
+        Parameters
+        ----------
+        warnings : str, optional
+            Whether or not to warn if the table doesn't exist. Can be either
+            `warn` or `ignore`, by default `warn`
+
+        Raises
+        ------
+        ValueError
+            If ``warnings`` is not ``'warn'`` or ``'ignore'``.
+        """
+        misc.can_drop_table(self, warnings)
         if self.exists():
             _utils.delete_folder_tree(self._table_path, current_db())
             # Reset the metadata indices:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ class SetupDB:
             store = fs.Store(store_name)
             for table in store.list_tables():
                 store.drop_table(table)
-            fs.drop_store(store_name, errors="ignore")
+            fs.drop_store(store_name, warnings="ignore")
         fs.disconnect()
         shutil.rmtree(DB_PATH, ignore_errors=False)
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -35,6 +35,13 @@ from .make_table import (
     unsorted_string_index,
 )
 from .misc import get_partition_size
+from .partitions import (
+    assert_partition_bounds_are_ordered,
+    assert_partition_metadata_matches_files,
+    partition_layout,
+    partition_names,
+    pruned_partitions,
+)
 from .split_table import split_table
 
 DB_PATH = join("tests", "_db")
@@ -51,6 +58,8 @@ __all__ = [
     "TABLE_NAME",
     "TABLE_PATH",
     "assert_df_equals",
+    "assert_partition_bounds_are_ordered",
+    "assert_partition_metadata_matches_files",
     "assert_store_table_equal",
     "assert_table_equals",
     "change_dtype",
@@ -64,6 +73,9 @@ __all__ = [
     "get_partition_size",
     "insert_column_names_at",
     "make_table",
+    "partition_layout",
+    "partition_names",
+    "pruned_partitions",
     "regenerate_values",
     "shuffle_cols",
     "sort_table",

--- a/tests/fixtures/partitions.py
+++ b/tests/fixtures/partitions.py
@@ -1,0 +1,74 @@
+"""Inspect how a stored table is split into partitions.
+
+Put helpers that read partition bounds, resolve which partitions a read opens,
+or compare partition metadata against the partition files on disk here.
+"""
+
+import itertools
+import os
+from collections import namedtuple
+
+import pyarrow as pa
+from pyarrow import ipc
+
+from featherstore._table.common import format_rows_arg
+from featherstore._table.read import get_partition_names
+
+Partition = namedtuple("Partition", ["name", "min", "max", "num_rows"])
+
+
+def partition_layout(table):
+    """The bounds of every partition of `table`, ordered by partition id."""
+    partition_data = table._partition_data.read()
+    return [
+        Partition(name, bounds["min"], bounds["max"], bounds["num_rows"])
+        for name, bounds in partition_data.items()
+    ]
+
+
+def partition_names(partitions):
+    """The partition ids of `partitions`."""
+    return [partition.name for partition in partitions]
+
+
+def pruned_partitions(table, rows):
+    """The partitions a read of `rows` narrows down to."""
+    rows = format_rows_arg(rows, to_dtype=table._table_data["index_dtype"])
+    return get_partition_names(table, rows)
+
+
+def assert_partition_metadata_matches_files(table):
+    """The partition metadata describes exactly the partition files on disk."""
+    partitions = partition_layout(table)
+
+    assert partition_names(partitions) == _stored_partition_names(table)
+    assert table._table_data["num_partitions"] == len(partitions)
+    assert table._table_data["num_rows"] == sum(p.num_rows for p in partitions)
+
+    for partition in partitions:
+        index = _read_partition_index(table, partition.name)
+        assert partition.min == index[0]
+        assert partition.max == index[-1]
+        assert partition.num_rows == len(index)
+
+
+def assert_partition_bounds_are_ordered(table):
+    """Every partition starts strictly after the preceding one ends."""
+    partitions = partition_layout(table)
+    for partition, next_partition in itertools.pairwise(partitions):
+        assert partition.max < next_partition.min
+
+
+def _stored_partition_names(table):
+    file_names = os.listdir(table._table_path)
+    return sorted(
+        os.path.splitext(name)[0] for name in file_names if name.endswith(".feather")
+    )
+
+
+def _read_partition_index(table, partition_name):
+    path = os.path.join(table._table_path, f"{partition_name}.feather")
+    index_name = table._table_data["index_name"]
+    with pa.OSFile(path, "r") as source:
+        partition = ipc.open_file(source).read_all()
+    return partition[index_name].to_pylist()

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -14,12 +14,17 @@ from featherstore.exceptions import (
 from .fixtures import (
     TABLE_NAME,
     assert_df_equals,
+    assert_partition_bounds_are_ordered,
+    assert_partition_metadata_matches_files,
     assert_table_equals,
     convert_table,
     default_index,
     get_index_name,
     get_partition_size,
     make_table,
+    partition_layout,
+    partition_names,
+    pruned_partitions,
     shuffle_cols,
     sort_table,
     sorted_datetime_index,
@@ -91,6 +96,42 @@ def test_append_custom_values_to_default_index(store):
     table.append(append_df2, warnings="ignore")
     # Assert
     assert_table_equals(table, expected)
+
+
+def test_append_that_overflows_the_last_partition_splits_it(store):
+    # Arrange
+    full_df = make_table(default_index, rows=36, astype="pandas")
+    original_df, append_df = split_table(full_df, rows={"after": 30}, iloc=True)
+
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    # Act
+    table.append(append_df, warnings="ignore")
+    # Assert
+    appended = partition_layout(table)
+    assert partition_names(appended[:-1]) == partition_names(partitions)
+    assert_partition_bounds_are_ordered(table)
+    assert_partition_metadata_matches_files(table)
+
+
+def test_reading_after_the_new_seam_opens_only_the_split_off_partition(store):
+    # Arrange
+    full_df = make_table(default_index, rows=36, astype="pandas")
+    original_df, append_df = split_table(full_df, rows={"after": 30}, iloc=True)
+
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+    table.append(append_df, warnings="ignore")
+
+    split_off = partition_layout(table)[-1]
+    # Act
+    pruned = pruned_partitions(table, {"after": split_off.min})
+    # Assert
+    assert pruned == [split_off.name]
 
 
 def _non_matching_index_dtype():

--- a/tests/test_db_and_connection.py
+++ b/tests/test_db_and_connection.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import warnings
+
+import pytest
 
 import featherstore as fs
 
@@ -76,6 +79,26 @@ def test_create_store(create_db, connect_to_db):
     assert stores == ["test_store"]
 
 
+def test_create_store_warns_when_store_already_exists(create_db, connect_to_db):
+    # Arrange
+    fs.create_store("test_store")
+    # Act / Assert
+    with pytest.warns(UserWarning, match="already exists"):
+        store = fs.create_store("test_store")
+    assert store.name == "test_store"
+    assert fs.list_stores() == ["test_store"]
+
+
+def test_create_store_can_ignore_existing_store_warning(create_db, connect_to_db):
+    # Arrange
+    fs.create_store("test_store")
+    # Act / Assert
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        store = fs.create_store("test_store", warnings="ignore")
+    assert store.name == "test_store"
+
+
 def test_drop_store(create_db, connect_to_db):
     # Arrange
     store = fs.create_store("test_store")
@@ -85,6 +108,20 @@ def test_drop_store(create_db, connect_to_db):
     # Assert
     assert stores_existed_before_delete
     assert not fs.store_exists(store.name)
+
+
+def test_drop_store_warns_when_store_does_not_exist(create_db, connect_to_db):
+    # Act / Assert
+    with pytest.warns(UserWarning, match="doesn't exist"):
+        fs.drop_store("missing_store")
+    assert not fs.store_exists("missing_store")
+
+
+def test_drop_store_can_ignore_missing_store_warning(create_db, connect_to_db):
+    # Act / Assert
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fs.drop_store("missing_store", warnings="ignore")
 
 
 def test_store_drop(store):

--- a/tests/test_drop.py
+++ b/tests/test_drop.py
@@ -12,6 +12,8 @@ from featherstore.exceptions import (
 
 from .fixtures import (
     TABLE_NAME,
+    assert_df_equals,
+    assert_partition_metadata_matches_files,
     assert_table_equals,
     continuous_datetime_index,
     continuous_string_index,
@@ -19,6 +21,8 @@ from .fixtures import (
     fake_default_index,
     get_partition_size,
     make_table,
+    partition_layout,
+    partition_names,
     sorted_string_index,
     split_table,
 )
@@ -91,6 +95,135 @@ def test_default_index_behavior_when_dropping(store, rows):
     table.drop(rows=rows)
     # Assert
     assert_table_equals(table, expected)
+
+
+def _drop_before_a_partitions_last_row(partitions):
+    return {"before": partitions[0].max}
+
+
+def _drop_after_a_partitions_first_row(partitions):
+    return {"after": partitions[-1].min}
+
+
+def _drop_between_two_adjacent_partitions(partitions):
+    return {"between": [partitions[1].max, partitions[2].min]}
+
+
+def _drop_rows_on_both_sides_of_a_seam(partitions):
+    return [partitions[1].max, partitions[2].min]
+
+
+SEAM_DROPS = [
+    _drop_before_a_partitions_last_row,
+    _drop_after_a_partitions_first_row,
+    _drop_between_two_adjacent_partitions,
+    _drop_rows_on_both_sides_of_a_seam,
+]
+SEAM_DROP_IDS = [seam_drop.__name__ for seam_drop in SEAM_DROPS]
+
+
+@pytest.mark.parametrize("seam_drop", SEAM_DROPS, ids=SEAM_DROP_IDS)
+def test_dropping_at_a_partition_seam(store, seam_drop):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    rows = seam_drop(partition_layout(table))
+    expected, _ = split_table(original_df, rows=rows)
+    # Act
+    table.drop(rows=rows)
+    # Assert
+    assert_table_equals(table, expected)
+    assert_partition_metadata_matches_files(table)
+
+
+def test_dropping_a_partitions_last_row_pulls_the_next_row_across_the_seam(store):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    # Act
+    table.drop_rows([partitions[0].max])
+    # Assert
+    assert partition_layout(table)[0].max == partitions[1].min
+    assert_partition_metadata_matches_files(table)
+
+
+def _drop_the_first_partitions_last_row(store, original_df):
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    seam = partition_layout(table)[0].max
+    table.drop_rows([seam])
+    return table, seam
+
+
+def test_reading_before_a_dropped_seam_value_excludes_it(store):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    table, dropped_seam = _drop_the_first_partitions_last_row(store, original_df)
+
+    expected = original_df.drop(index=dropped_seam).loc[:dropped_seam]
+    # Act
+    df = table.read_pandas(rows={"before": dropped_seam})
+    # Assert
+    assert_df_equals(df, expected)
+
+
+def test_reading_after_the_moved_seam_finds_the_row_that_crossed_it(store):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    table, dropped_seam = _drop_the_first_partitions_last_row(store, original_df)
+    moved_seam = partition_layout(table)[0].max
+
+    expected = original_df.drop(index=dropped_seam).loc[moved_seam:]
+    # Act
+    df = table.read_pandas(rows={"after": moved_seam})
+    # Assert
+    assert_df_equals(df, expected)
+
+
+def test_dropping_every_row_of_a_middle_partition_removes_it(store):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    emptied = partitions[2]
+    # Act
+    table.drop_rows({"between": [emptied.min, emptied.max]})
+    # Assert
+    remaining = partitions[:2] + partitions[3:]
+    assert partition_names(partition_layout(table)) == partition_names(remaining)
+    assert_partition_metadata_matches_files(table)
+
+
+def test_reading_across_a_removed_partition_returns_the_surrounding_rows(store):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    emptied = partitions[2]
+    table.drop_rows({"between": [emptied.min, emptied.max]})
+
+    across_the_hole = [partitions[1].max, partitions[3].min]
+    expected = original_df.drop(index=original_df.loc[emptied.min : emptied.max].index)
+    expected = expected.loc[across_the_hole[0] : across_the_hole[1]]
+    # Act
+    df = table.read_pandas(rows={"between": across_the_hole})
+    # Assert
+    assert_df_equals(df, expected)
 
 
 INVALID_ROWS_DTYPE = "c1, c2, c3"

--- a/tests/test_general_table_methods.py
+++ b/tests/test_general_table_methods.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from featherstore._metadata import METADATA_FOLDER_NAME
@@ -46,6 +48,20 @@ def test_drop_table(store):
     # Assert
     table_names = store.list_tables()
     assert table_names == []
+
+
+def test_drop_table_warns_when_table_does_not_exist(store):
+    # Act / Assert
+    with pytest.warns(UserWarning, match="not found"):
+        store.drop_table(TABLE_NAME)
+    assert store.list_tables() == []
+
+
+def test_drop_table_can_ignore_missing_table_warning(store):
+    # Act / Assert
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        store.drop_table(TABLE_NAME, warnings="ignore")
 
 
 def test_list_tables_like(store):

--- a/tests/test_insert_rows.py
+++ b/tests/test_insert_rows.py
@@ -15,6 +15,9 @@ from featherstore.exceptions import (
 
 from .fixtures import (
     TABLE_NAME,
+    assert_df_equals,
+    assert_partition_bounds_are_ordered,
+    assert_partition_metadata_matches_files,
     assert_table_equals,
     continuous_datetime_index,
     continuous_string_index,
@@ -23,6 +26,7 @@ from .fixtures import (
     get_index_name,
     get_partition_size,
     make_table,
+    partition_layout,
     sort_table,
     sorted_float_index,
     sorted_string_index,
@@ -143,6 +147,54 @@ def test_insert_rows_with_successive_mid_table_inserts(store, num_partitions):
     table.insert_rows(second_insert, warnings="ignore")
     # Assert
     assert_table_equals(table, expected)
+
+
+def test_inserting_into_a_partition_seam_extends_the_preceding_partition(store):
+    # Arrange
+    original_df = make_table(sorted_float_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    seam_value = _midpoint(partitions[0].max, partitions[1].min)
+    insert_df = _row_at(original_df, seam_value)
+    # Act
+    table.insert_rows(insert_df, warnings="ignore")
+    # Assert
+    assert partition_layout(table)[0].max == seam_value
+    assert_partition_bounds_are_ordered(table)
+    assert_partition_metadata_matches_files(table)
+
+
+def test_reading_across_a_seam_that_has_been_inserted_into(store):
+    # Arrange
+    original_df = make_table(sorted_float_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    seam_start, seam_end = partitions[0].max, partitions[1].min
+    insert_df = _row_at(original_df, _midpoint(seam_start, seam_end))
+    table.insert_rows(insert_df, warnings="ignore")
+
+    expected = sort_table(pd.concat([original_df, insert_df]))
+    expected = expected.loc[seam_start:seam_end]
+    # Act
+    df = table.read_pandas(rows={"between": [seam_start, seam_end]})
+    # Assert
+    assert_df_equals(df, expected)
+
+
+def _midpoint(lower, upper):
+    return (lower + upper) / 2
+
+
+def _row_at(df, index_value):
+    row = df.head(1).copy()
+    row.index = pd.Index([index_value], name=df.index.name)
+    return row
 
 
 def test_insert_rows_warns_on_unsorted_index(store):

--- a/tests/test_io_general.py
+++ b/tests/test_io_general.py
@@ -24,6 +24,9 @@ from .fixtures import (
     get_index_name,
     get_partition_size,
     make_table,
+    partition_layout,
+    partition_names,
+    pruned_partitions,
     sort_table,
     sorted_binary_index,
     sorted_date32_index,
@@ -34,6 +37,7 @@ from .fixtures import (
     sorted_time32_index,
     sorted_timedelta_index,
     sorted_uint_index,
+    split_table,
     unsorted_int_index,
     unsorted_string_index,
 )
@@ -117,6 +121,89 @@ def test_empty_df_io(store, astype):
     table.write(expected, partition_size=partition_size)
     # Assert
     assert_table_equals(table, expected)
+
+
+def _before_the_first_partitions_last_row(partitions):
+    return {"before": partitions[0].max}, partitions[:1]
+
+
+def _before_a_partitions_last_row(partitions):
+    return {"before": partitions[1].max}, partitions[:2]
+
+
+def _before_a_partitions_first_row(partitions):
+    return {"before": partitions[2].min}, partitions[:3]
+
+
+def _after_a_partitions_last_row(partitions):
+    return {"after": partitions[1].max}, partitions[1:]
+
+
+def _after_a_partitions_first_row(partitions):
+    return {"after": partitions[2].min}, partitions[2:]
+
+
+def _after_the_last_partitions_first_row(partitions):
+    return {"after": partitions[-1].min}, partitions[-1:]
+
+
+def _between_two_adjacent_partitions(partitions):
+    return {"between": [partitions[1].max, partitions[2].min]}, partitions[1:3]
+
+
+def _between_a_partitions_own_bounds(partitions):
+    return {"between": [partitions[2].min, partitions[2].max]}, partitions[2:3]
+
+
+def _rows_on_both_sides_of_a_seam(partitions):
+    return [partitions[1].max, partitions[2].min], partitions[1:3]
+
+
+SEAM_FILTERS = [
+    _before_the_first_partitions_last_row,
+    _before_a_partitions_last_row,
+    _before_a_partitions_first_row,
+    _after_a_partitions_last_row,
+    _after_a_partitions_first_row,
+    _after_the_last_partitions_first_row,
+    _between_two_adjacent_partitions,
+    _between_a_partitions_own_bounds,
+    _rows_on_both_sides_of_a_seam,
+]
+SEAM_FILTER_IDS = [seam_filter.__name__ for seam_filter in SEAM_FILTERS]
+
+
+@pytest.mark.parametrize("seam_filter", SEAM_FILTERS, ids=SEAM_FILTER_IDS)
+def test_reading_at_a_partition_seam_returns_the_boundary_rows(store, seam_filter):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    rows, _ = seam_filter(partition_layout(table))
+    _, expected = split_table(original_df, rows=rows)
+    # Act
+    df = table.read_pandas(rows=rows)
+    # Assert
+    assert_df_equals(df, expected)
+
+
+@pytest.mark.parametrize("seam_filter", SEAM_FILTERS, ids=SEAM_FILTER_IDS)
+def test_reading_at_a_partition_seam_prunes_to_the_matching_partitions(
+    store, seam_filter
+):
+    # Arrange
+    original_df = make_table(default_index, astype="pandas")
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    rows, expected = seam_filter(partition_layout(table))
+    # Act
+    pruned = pruned_partitions(table, rows)
+    # Assert
+    assert pruned == partition_names(expected)
 
 
 def _invalid_table_dtype():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -12,6 +12,7 @@ from featherstore.exceptions import (
 
 from .fixtures import (
     TABLE_NAME,
+    assert_partition_metadata_matches_files,
     assert_table_equals,
     continuous_datetime_index,
     continuous_string_index,
@@ -21,6 +22,7 @@ from .fixtures import (
     get_index_name,
     get_partition_size,
     make_table,
+    partition_layout,
     regenerate_values,
     sorted_string_index,
     split_table,
@@ -126,6 +128,27 @@ def _assert_partitions_are_same_structure_after_update(
         assert index_start == metadata["min"]
         assert index_end == metadata["max"]
         assert num_rows == metadata["num_rows"]
+
+
+def test_update_spanning_a_partition_seam(store):
+    # Arrange
+    original_df = make_table(astype="pandas")
+    original_df.index.name = "index"
+
+    partition_size = get_partition_size(original_df)
+    table = store.select_table(TABLE_NAME)
+    table.write(original_df, partition_size=partition_size)
+
+    partitions = partition_layout(table)
+    seam_rows = [partitions[0].max, partitions[1].min]
+    _, update_df = split_table(original_df, rows=seam_rows, cols=["c0", "c2"])
+    update_df = regenerate_values(update_df)
+    expected = update_table(original_df, update_df)
+    # Act
+    table.update(update_df)
+    # Assert
+    assert_table_equals(table, expected)
+    assert_partition_metadata_matches_files(table)
 
 
 def _update_table_not_supported_type():


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/partitions.py` with helpers to read partition bounds, verify metadata matches on-disk `.feather` files, and assert which partitions a read filter prunes to.
- Add seam regression tests across read, drop, update, append, and insert that exercise predicates and mutations at partition boundaries (min/max index values).
- Tests derive seam values and expected partition ids from the layout captured after write, so they stay stable if partition-size heuristics change.

## Test plan

- [x] `uv run task lint:check`
- [x] `uv run task test:unit` (472 tests)