### PR TITLE
Polish README and docs wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,22 @@
 [![Dev Status](https://img.shields.io/pypi/status/featherstore?color=important)](https://pypi.org/project/FeatherStore/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/hakonmh/featherstore/blob/master/LICENSE)
 
-## High performance datastore built upon Apache Arrow & Feather
+## High-performance datastore built on Apache Arrow and Feather
 
-FeatherStore is a high performance datastore for storing Pandas DataFrames, Polars DataFrames,
-and PyArrow Tables. By saving data in the form of partitioned
-[Feather Files](https://arrow.apache.org/docs/python/feather.html), FeatherStore enables
-several operations on the stored tables, optimizing performance by selectively loading only
-the necessary segments of data:
+FeatherStore is a high-performance datastore for Pandas DataFrames, Polars DataFrames,
+and PyArrow Tables. Data is stored as partitioned
+[Feather files](https://arrow.apache.org/docs/python/feather.html), so FeatherStore can
+run several operations on stored tables while loading only the data each operation needs:
 
-* Partial reading of data
-* Append data
-* Insert rows and columns (Pandas, Polars DataFrame, or PyArrow Table)
-* Update data (Pandas, Polars DataFrame, or PyArrow Table)
-* Drop data
-* Read metadata (including column names, index, table dimensions, etc.)
-* Changing column types
+* Partial reads
+* Appends
+* Row and column inserts (Pandas, Polars, or PyArrow)
+* Updates (Pandas, Polars, or PyArrow)
+* Drops
+* Metadata reads (column names, index, table dimensions, and more)
+* Column type changes
 
-For more information on using FeatherStore, please refer to the
+For more information, see the
 [documentation](https://featherstore.readthedocs.io/en/stable/Quickstart.html).
 
 ## Using FeatherStore
@@ -48,27 +47,27 @@ df = pd.DataFrame(randn(5, 4), index=dates, columns=list("ABCD"))
 fs.create_database('path/to/db')
 fs.connect('path/to/db')
 fs.database_exists('path/to/db')  # True
-# Creates a data store
+# Create a store
 fs.create_store('example_store')
-# List existing stores in current database
+# List existing stores in the current database
 fs.list_stores()
 
 ['example_store']
 
->>> # Connects to store
+>>> # Connect to the store
 store = fs.Store('example_store')
-# Saves table to store; partition size defines the size of each partition in bytes
+# Save the table to the store; partition_size is the size of each partition in bytes
 PARTITION_SIZE = 128  # bytes
 store.write_table('example_table', df, partition_size=PARTITION_SIZE)
-# Lists existing tables in current store
+# List existing tables in the current store
 store.list_tables()
 
 ['example_table']
 
->>> # FeatherStore can read tables as Arrow Tables, Pandas DataFrames or Polars DataFrames
+>>> # FeatherStore can read tables as Arrow Tables, Pandas DataFrames, or Polars DataFrames
 store.read_pandas('example_table')
-# store.read_arrow('example_table') for reading to Arrow Tables
-# store.read_polars('example_table') for reading to Polars DataFrames
+# store.read_arrow('example_table') for Arrow Tables
+# store.read_polars('example_table') for Polars DataFrames
 
                    A         B         C         D
 2021-01-01  0.402138 -0.016436 -0.565256  0.520086
@@ -77,13 +76,13 @@ store.read_pandas('example_table')
 2021-01-04 -0.835711 -0.575801 -0.650543 -0.411509
 2021-01-05 -0.649335 -0.830602  1.191749  0.396745
 
->>> # FeatherStore supports appending data without loading in the full table
+>>> # FeatherStore can append data without loading the full table
 new_dates = pd.date_range("2021-01-06", periods=1)
 df1 = pd.DataFrame(randn(1, 4), index=new_dates, columns=list("ABCD"))
 store.append_table('example_table', df1)
 
->>> # Insert rows or columns via Table.insert() (dispatches on column names).
-# update / insert_* also accept Polars DataFrames and PyArrow Tables.
+>>> # Insert rows or columns with Table.insert(), which dispatches based on column names.
+# Table.update() and the insert methods also accept Polars DataFrames and PyArrow Tables.
 table = store.select_table('example_table')
 new_rows = pd.DataFrame(randn(1, 4), index=[pd.Timestamp("2021-01-07")], columns=list("ABCD"))
 table.insert(new_rows)  # matching column names -> inserts rows
@@ -91,7 +90,7 @@ table.insert(new_rows)  # matching column names -> inserts rows
 new_col = pd.DataFrame({'E': randn(7)}, index=table.read_pandas().index)
 table.insert(new_col, idx=4)  # new column name -> inserts column at position 4
 
->>> # It also supports querying parts of the data
+>>> # Query parts of the data
 store.read_pandas('example_table', rows={'after': '2021-01-05'}, cols=['D', 'A'])
 
                    D         A
@@ -102,13 +101,13 @@ store.read_pandas('example_table', rows={'after': '2021-01-05'}, cols=['D', 'A']
 
 ## Performance
 
-FeatherStore is very fast, and in fact is one of the best performing solutions available.
-See the full performance benchmark in the [documentation](https://featherstore.readthedocs.io/en/stable/Benchmarks.html).
+FeatherStore is fast on both small and large tables.
+See the full comparison in the [documentation](https://featherstore.readthedocs.io/en/stable/Benchmarks.html).
 
 ## Installation
 
-FeatherStore can be installed by using `$ pip install featherstore` or directly from
-source by using `$ pip install git+https://github.com/hakonmh/featherstore.git`
+Install FeatherStore with `$ pip install featherstore`, or from source with
+`$ pip install git+https://github.com/hakonmh/featherstore.git`.
 
 ## Requirements
 
@@ -123,4 +122,4 @@ These are installed automatically with `pip install featherstore`.
 
 ## Documentation
 
-Want to know about all the features FeatherStore support? [Read the docs!](https://featherstore.readthedocs.io/en/stable/index.html)
+See the [documentation](https://featherstore.readthedocs.io/en/stable/index.html) for the full API and feature set.

--- a/docs/API Reference.rst
+++ b/docs/API Reference.rst
@@ -1,7 +1,7 @@
 API Reference
 =============
 
-This page gives an overview of all public FeatherStore objects, functions and methods.
+This page gives an overview of all public FeatherStore objects, functions, and methods.
 
 .. toctree::
    :maxdepth: 4

--- a/docs/API/Exceptions.rst
+++ b/docs/API/Exceptions.rst
@@ -2,7 +2,7 @@ Exceptions
 ----------
 
 All domain errors inherit from :class:`~featherstore.exceptions.FeatherStoreError`.
-Category bases allow catching related errors together (for example,
+Category base classes let you catch related errors together (for example,
 :class:`~featherstore.exceptions.ColumnError` for any column-related failure).
 
 Argument validation (invalid types, missing required arguments) still raises

--- a/docs/API/Snapshot.rst
+++ b/docs/API/Snapshot.rst
@@ -1,8 +1,8 @@
 Snapshot
 --------
 .. note::
-    You can back-up your data by creating snapshots using ``Table.create_snapshot()``
-    and ``Store.create_snapshot()``
+    You can back up your data by creating snapshots with ``Table.create_snapshot()``
+    and ``Store.create_snapshot()``.
 
 .. automodule:: featherstore.snapshot
    :members:

--- a/docs/Benchmarks.rst
+++ b/docs/Benchmarks.rst
@@ -14,7 +14,8 @@ The benchmarks were run on the following hardware:
 Compared with other libraries
 +++++++++++++++++++++++++++++
 
-The code used for these benchmarks can be found `here <https://github.com/hakonmh/featherstore/blob/master/benchmarks/format_comparison.py>`_.
+The code for the format comparison is in
+`benchmarks/format_comparison.py <https://github.com/hakonmh/featherstore/blob/master/benchmarks/format_comparison.py>`_.
 
 First dataset
 -------------
@@ -55,7 +56,8 @@ speed.
 Table operation benchmarks
 ++++++++++++++++++++++++++
 
-The code used for these (and other) benchmarks can be found `here <https://github.com/hakonmh/featherstore/blob/master/benchmarks/table_operations.py>`_.
+The code for the table-operation benchmarks is in
+`benchmarks/table_operations.py <https://github.com/hakonmh/featherstore/blob/master/benchmarks/table_operations.py>`_.
 
 Pandas vs Polars and Arrow
 --------------------------

--- a/docs/Benchmarks.rst
+++ b/docs/Benchmarks.rst
@@ -50,8 +50,8 @@ floats, and datetimes, with 10 columns of each type.
     :width: 750
     :align: center
 
-On this dataset, FeatherStore matches Pickle on read speed and Feather on write
-speed.
+Here's where FeatherStore really shines, matching Pickle on read speed and
+Feather on write speed.
 
 Table operation benchmarks
 ++++++++++++++++++++++++++

--- a/docs/Benchmarks.rst
+++ b/docs/Benchmarks.rst
@@ -103,6 +103,8 @@ reads improve by a similar amount.
 Reading 25% of the rows takes between 3.5 s and 5.0 s for Pandas, depending on
 whether you pass a list of rows or a range query.
 
-Row-filtering performance depends on partition size. Smaller partitions skip
-more rows when reading, at the cost of slower full-table reads and writes.
-These benchmarks used the default partition size of 128 MB.
+It should be noted that the performance when filtering rows is dependent
+on the partition size used. Smaller partitions allow us to skip more rows
+when reading, with the trade-off being slower performance when doing full table
+reads and writes. In these benchmarks, the default 128 MB was used as the
+partition size.

--- a/docs/Benchmarks.rst
+++ b/docs/Benchmarks.rst
@@ -1,27 +1,27 @@
 Benchmarks
 ==========
 
-In this benchmark we'll compare how well FeatherStore, Feather, Parquet, CSV,
-Pickle and DuckDB perform when reading and writing Pandas DataFrames.
+This page compares FeatherStore, Feather, Parquet, CSV, Pickle, and DuckDB
+when reading and writing Pandas DataFrames.
 
-The benchmark ran on the following computer:
+The benchmarks were run on the following hardware:
 
 * CPU: Intel© Core™ i5-11600
 * RAM: 48 GB DDR4 (3200 MHz)
-* SSD: 1 TB M.2 NVMe (3470/3000 Read/Write MBps)
-* GPU: NVIDIA GeForce GTX 1060 6GB (Not used during the benchmark)
+* SSD: 1 TB M.2 NVMe (3470/3000 MB/s read/write)
+* GPU: NVIDIA GeForce GTX 1060 6GB (not used during the benchmark)
 
-VS Other Libraries
-++++++++++++++++++
+Compared with other libraries
++++++++++++++++++++++++++++++
 
 The code used for these benchmarks can be found `here <https://github.com/hakonmh/featherstore/blob/master/benchmarks/format_comparison.py>`_.
 
-First Dataset
---------------
+First dataset
+-------------
 
-Let's start small, the first dataset is made up of 6,000 fields of random
-data with the shape of 1,000 rows and 6 columns. The data consists of strings,
-ints, uints, bools, floats, and datetime, with one column of each data type.
+The first dataset is small: 6,000 random fields in a table of 1,000 rows and 6
+columns. It includes strings, ints, uints, bools, floats, and datetimes, with
+one column of each type.
 
 .. image:: images/write_first.png
     :width: 750
@@ -31,16 +31,15 @@ ints, uints, bools, floats, and datetime, with one column of each data type.
     :width: 750
     :align: center
 
-As you can see, for small DataFrames, Pickle is the fastest solution. While
-FeatherStore is around the middle of the pack for both reads and writes.
+For small DataFrames, Pickle is the fastest option. FeatherStore is neither
+the fastest nor the slowest for reads or writes.
 
-Second Dataset
+Second dataset
 --------------
 
-The second dataset is made up of 600 million fields of random data in the shape
-10 million rows and 60 columns (Approx. 6.4 Gb of data when stored as CSV).
-The data consists of strings, ints, uints, bools, floats, and datetimes, with
-10 columns of each data type.
+The second dataset has 600 million random fields: 10 million rows and 60 columns
+(about 6.4 GB when stored as CSV). It includes strings, ints, uints, bools,
+floats, and datetimes, with 10 columns of each type.
 
 .. image:: images/write_second.png
     :width: 750
@@ -50,10 +49,10 @@ The data consists of strings, ints, uints, bools, floats, and datetimes, with
     :width: 750
     :align: center
 
-Here's where FeatherStore really shines, matching Pickle on read speed and
-Feather on write speed.
+On this dataset, FeatherStore matches Pickle on read speed and Feather on write
+speed.
 
-Table Operation Benchmarks
+Table operation benchmarks
 ++++++++++++++++++++++++++
 
 The code used for these (and other) benchmarks can be found `here <https://github.com/hakonmh/featherstore/blob/master/benchmarks/table_operations.py>`_.
@@ -61,15 +60,13 @@ The code used for these (and other) benchmarks can be found `here <https://githu
 Pandas vs Polars and Arrow
 --------------------------
 
-In addition to supporting reading and writing Pandas DataFrames, FeatherStore
-also supports reading and writing Polars DataFrames and PyArrow Tables.
-These two data structures use the Apache Arrow Columnar Format as a memory
-model, allowing reads and writes without serializing and deserializing to and
-from Pandas.
+In addition to Pandas DataFrames, FeatherStore can read and write Polars
+DataFrames and PyArrow Tables. These two structures use the Apache Arrow
+Columnar Format as a memory model, so reads and writes can skip serializing and
+deserializing through Pandas.
 
-We will benchmark using the second dataset, comparing reading and writing
-the dataset as Pandas DataFrame, Polars DataFrame, and PyArrow Table
-using FeatherStore.
+The charts below use the second dataset and compare reading and writing it as a
+Pandas DataFrame, a Polars DataFrame, and a PyArrow Table with FeatherStore.
 
 .. image:: images/write_internal.png
     :width: 750
@@ -79,34 +76,31 @@ using FeatherStore.
     :width: 750
     :align: center
 
-Skipping serialization makes FeatherStore extremely fast when reading to Arrow
-and Polars. It's not easy to see based on the chart, but read Arrow is clocking
-in at just 4.36 ms, while read Polars takes 362 ms.
+Skipping serialization makes FeatherStore very fast when reading to Arrow and
+Polars. Reading to Arrow takes 4.36 ms; reading to Polars takes 362 ms. The
+chart scale makes that difference hard to see.
 
-Predicate Filtering
+Predicate filtering
 -------------------
 
-In addition to the performance given to us by the underlying Feather files,
-FeatherStore partitions our data into multiple files. This allows us to read
-parts of the data without reading the full table, saving both time and memory
-usage.
+On top of the performance of the underlying Feather files, FeatherStore
+partitions data into multiple files. That lets you read part of a table without
+loading all of it, which saves both time and memory.
 
 .. image:: images/read_cols_internal.png
     :width: 750
     :align: center
 
-Reading 25 % of the columns cuts the time to read Pandas from 11.5 s to 4.8 s.
-Similar improvements can also be seen when reading Polars.
+Reading 25% of the columns cuts Pandas read time from 11.5 s to 4.8 s. Polars
+reads improve by a similar amount.
 
 .. image:: images/read_rows_internal.png
     :width: 750
     :align: center
 
-Reading 25 % of the rows takes between 3.5 s and 5.0 s when reading Pandas,
-dependent on how you read them (list of rows vs range query).
+Reading 25% of the rows takes between 3.5 s and 5.0 s for Pandas, depending on
+whether you pass a list of rows or a range query.
 
-It should be noted that the performance when filtering rows is dependent
-on the partition size used. Smaller partitions allow us to skip more rows
-when reading, with the trade-off being slower performance when doing full table
-reads and writes. In these benchmarks, the default 128 Mb was used as the
-partition size.
+Row-filtering performance depends on partition size. Smaller partitions skip
+more rows when reading, at the cost of slower full-table reads and writes.
+These benchmarks used the default partition size of 128 MB.

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -1,21 +1,20 @@
 Overview
 ========
 
-FeatherStore is a high performance datastore for storing Pandas DataFrames, Polars DataFrames,
-and PyArrow Tables. By saving data in the form of partitioned
-`Feather Files <https://arrow.apache.org/docs/python/feather.html>`_, FeatherStore enables
-several operations on the stored tables, optimizing performance by selectively loading only
-the necessary segments of data:
+FeatherStore is a high-performance datastore for Pandas DataFrames, Polars DataFrames,
+and PyArrow Tables. Data is stored as partitioned
+`Feather files <https://arrow.apache.org/docs/python/feather.html>`_, so FeatherStore can
+run several operations on stored tables while loading only the data each operation needs:
 
-* Partial reading of data
-* Append data
-* Insert rows and columns (Pandas, Polars DataFrame, or PyArrow Table)
-* Update data (Pandas, Polars DataFrame, or PyArrow Table)
-* Drop data
-* Read metadata (including column names, indices, table dimensions, etc.)
-* Changing column types
+* Partial reads
+* Appends
+* Row and column inserts (Pandas, Polars, or PyArrow)
+* Updates (Pandas, Polars, or PyArrow)
+* Drops
+* Metadata reads (column names, index, table dimensions, and more)
+* Column type changes
 
-For more information on using FeatherStore, please refer to the
+For more information, see the
 `user guide <Quickstart.html>`_.
 
 Installation
@@ -23,7 +22,7 @@ Installation
 | The project is hosted on PyPI at:
 | https://pypi.org/project/FeatherStore/
 
-| To install FeatherStore, simply use pip
+| To install FeatherStore, use pip:
 
 .. code-block::
 
@@ -40,7 +39,7 @@ Installation
 Python version support
 ----------------------
 
-Officially Python 3.11 and up is supported.
+Python 3.11 and later are officially supported.
 
 Dependency requirements
 -----------------------
@@ -53,13 +52,13 @@ FeatherStore 0.3.0 requires:
 
 These are installed automatically with ``pip install featherstore``.
 
-Source Code
+Source code
 +++++++++++
 
-| The source code is currently hosted on GitHub at:
+| The source code is hosted on GitHub at:
 | https://github.com/hakonmh/featherstore
 
-LICENSE
+License
 +++++++
 
 `MIT <https://github.com/hakonmh/featherstore/blob/master/LICENSE>`_
@@ -67,7 +66,7 @@ LICENSE
 Contributions
 +++++++++++++
 
-All contributions, bug reports, bug fixes, documentation improvements, enhancements and ideas are welcome.
+All contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas are welcome.
 
 | Issues are posted on:
 | https://github.com/hakonmh/featherstore/issues

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -1,8 +1,8 @@
 Quickstart
 ==========
 
-This is a short introduction to using FeatherStore and an overview of its basic functionality.
-For a complete guide to FeatherStores classes, functions, and methods please visit the
+This is a short introduction to FeatherStore and its basic features.
+For a complete guide to FeatherStore's classes, functions, and methods, see the
 `API reference <API%20Reference.html>`_.
 
 | The project is hosted on PyPI at:
@@ -11,7 +11,7 @@ For a complete guide to FeatherStores classes, functions, and methods please vis
 Installation
 ++++++++++++
 
-| To install FeatherStore, simply use pip
+| To install FeatherStore, use pip:
 
 .. code-block::
 
@@ -34,14 +34,14 @@ FeatherStore 0.3.0 requires Python 3.11 or newer and the following packages:
 * polars[timezone] >= 1.21.0
 * pyarrow >= 14.0.0
 
-Starting Up
------------
+Getting started
+---------------
 
 .. code-block:: python
 
     import featherstore as fs
 
-To create and connect to a new database simply use:
+To create and connect to a new database, use:
 
 .. code-block:: python
 
@@ -49,13 +49,13 @@ To create and connect to a new database simply use:
     fs.connect('/path/to/database_folder')
 
 You can check whether a path is already a database with ``fs.database_exists()``.
-You can later disconnect from the database by using ``fs.disconnect()``
+You can later disconnect from the database with ``fs.disconnect()``.
 
-Working with Stores
+Working with stores
 -------------------
 
-A database consists of one or more stores. A store is the basic unit for organization
-and where you can store your tables.
+A database contains one or more stores. A store groups tables and is the main
+unit of organization.
 
 .. code-block:: python
 
@@ -69,16 +69,16 @@ and where you can store your tables.
 
     fs.drop_store('store_2')
     fs.rename_store('store_1', to='example_store')
-    # Connect to store
+    # Connect to the store
     store = fs.Store('example_store')
 
-Reading and Writing Tables
+Reading and writing tables
 --------------------------
 
-FeatherStore supports reading and writing of Pandas DataFrames/Series, Polars
-DataFrames/Series and PyArrow tables.
+FeatherStore can read and write Pandas DataFrames and Series, Polars DataFrames
+and Series, and PyArrow Tables.
 
-First lets create a DataFrame to store.
+First, let's create a DataFrame to store.
 
 .. code-block:: python
 
@@ -96,8 +96,8 @@ First lets create a DataFrame to store.
     2021-01-04 -0.835711 -0.575801 -0.650543 -0.411509
     2021-01-05 -0.649335 -0.830602  1.191749  0.396745
 
-FeatherStore stores the tables as partitioned Feather files. The size of each partition
-is defined by using the ``partition_size`` parameter when writing a table.
+FeatherStore stores tables as partitioned Feather files. Set the size of each
+partition with the ``partition_size`` parameter when writing a table.
 
 .. code-block:: python
 
@@ -107,27 +107,28 @@ is defined by using the ``partition_size`` parameter when writing a table.
 
     >> ['example_table']
 
-The advantage with using partitioned Feather files that you can do different operations
-without loading in the full data.
+Partitioned Feather files let you run many operations without loading the full
+dataset.
 
 .. code-block:: python
 
-    # Creating a new DataFrame
+    # Create a new DataFrame
     new_dates = pd.date_range("2021-01-06", periods=1)
     df1 = pd.DataFrame(randn(1, 4), index=new_dates, columns=list("ABCD"))
-    # Appending to a FeatherStore table only loads in the last partition
+    # Appending to a FeatherStore table only loads the last partition
     store.append_table('example_table', df1)
 
-FeatherStore uses sorted indices to keep track of which partitions to open during
-a given operation.
+FeatherStore uses sorted indices to decide which partitions to open for a given
+operation.
 
-We can now read the stored data as Pandas DataFrame, Polars DataFrame or PyArrow Tables.
+You can read the stored data as a Pandas DataFrame, a Polars DataFrame, or a
+PyArrow Table.
 
 .. code-block:: python
 
     store.read_pandas('example_table')
-    # store.read_arrow('example_table') for reading to Arrow Tables
-    # store.read_polars('example_table') for reading to Polars DataFrames
+    # store.read_arrow('example_table') for Arrow Tables
+    # store.read_polars('example_table') for Polars DataFrames
 
     >>                 A         B         C         D
     2021-01-01  0.402138 -0.016436 -0.565256  0.520086
@@ -137,11 +138,11 @@ We can now read the stored data as Pandas DataFrame, Polars DataFrame or PyArrow
     2021-01-05 -0.649335 -0.830602  1.191749  0.396745
     2021-01-06 -0.408125 -0.420920  0.632606  0.606950
 
-We can also query parts of the data. FeatherStore uses predicate filtering to
-only load the partitions and columns specified by the query.
+You can also query parts of the data. FeatherStore uses predicate filtering to
+load only the partitions and columns specified by the query.
 
-By using sorted indices, FeatherStore allows for range-queries on rows by using
-``{'before': end}``, ``{'after': start}`` and ``{'between': [start, end]}``
+Sorted indices also allow range queries on rows with
+``{'before': end}``, ``{'after': start}``, and ``{'between': [start, end]}``.
 
 .. code-block:: python
 
@@ -152,10 +153,10 @@ By using sorted indices, FeatherStore allows for range-queries on rows by using
     2021-01-05  0.396745 -0.649335
     2021-01-06  0.606950  0.408125
 
-Inserting, Updating and Deleting Data
--------------------------------------
+Inserting, updating, and deleting data
+--------------------------------------
 
-First, let's create a new table to work with:
+First, create a new table to work with:
 
 .. code-block:: python
 
@@ -169,8 +170,8 @@ First, let's create a new table to work with:
     5 -0.353684  1.550073
     6  1.275938  1.054702
 
-We can use ``Store.select_table()`` to select a ``Table`` object, which contains
-more features for working with tables.
+Use ``Store.select_table()`` to select a ``Table`` object, which includes more
+methods for working with tables.
 
 .. code-block:: python
 
@@ -181,20 +182,19 @@ more features for working with tables.
 
     >> True
 
-One of those features is ``Table.insert()``, which inserts rows or columns
+One of those methods is ``Table.insert()``, which inserts rows or columns
 depending on the column names of the input data. If the input column names
 match the stored table, rows are inserted; otherwise columns are inserted.
 
 ``Table.update()``, ``Table.insert_rows()``, ``Table.insert_columns()``, and
-``Table.insert()`` accept Pandas DataFrames/Series, Polars DataFrames, and
+``Table.insert()`` accept Pandas DataFrames and Series, Polars DataFrames, and
 PyArrow Tables as input. Polars Series is not supported for these edit APIs.
 
 You can also call ``Table.insert_rows()`` or ``Table.insert_columns()`` directly
 when you want to be explicit about the operation.
 
 Pass ``warnings='ignore'`` to suppress sorting warnings when inserting rows or
-columns with an unsorted index (default is ``warnings='warn'``).
-
+columns with an unsorted index (the default is ``warnings='warn'``).
 
 .. code-block:: python
 
@@ -202,7 +202,7 @@ columns with an unsorted index (default is ``warnings='warn'``).
     table.insert(df2)  # matching column names -> inserts rows
     table.read_pandas()
 
-    # The data will be inserted into its sorted index position
+    # The data is inserted at its sorted index position
     >>        A         B
     1 -0.041727  0.957139
     2  2.163615 -0.708871
@@ -212,7 +212,7 @@ columns with an unsorted index (default is ``warnings='warn'``).
     6  1.275938  1.054702
 
 To add columns, pass data whose column names are not already in the table.
-Use ``idx`` to control where the new column(s) are placed. A single integer
+Use ``idx`` to control where the new columns are placed. A single integer
 inserts a block of columns at that position; a sequence places each column
 individually.
 
@@ -225,17 +225,18 @@ individually.
     # Append a single column to the end
     table.insert_columns(pd.DataFrame({'E': randn(6)}, index=index), idx=-1)
 
-Other features include ``Table.update()`` and ``Table.drop()`` which updates and deletes data.
+Other methods include ``Table.update()`` and ``Table.drop()``, which update and
+delete data.
 
 .. code-block:: python
 
-    df3 = pd.DataFrame([[0, 2], [1, 3]], index=[1, 2], columns=list("AB"))
+    df3 = pd.DataFrame([[0, 1], [2, 3]], index=[1, 2], columns=list("AB"))
     #    A  B
     # 1  0  1
     # 2  2  3
     table.update(df3)
     table.drop(rows={'after': 5})
-    # You can also drop columns using table.drop(cols=['col1', 'col2'])
+    # You can also drop columns with table.drop(cols=['col1', 'col2'])
 
     >>        A         B
     1  0.000000  1.000000

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Documentation
 =============
 
-Welcome to the FeatherStore documentation!
+Welcome to the FeatherStore documentation.
 
 Table of Contents
 -----------------

--- a/featherstore/connection.py
+++ b/featherstore/connection.py
@@ -51,9 +51,9 @@ def create_database(path, *, errors="raise", connect=True):
     path : str
         Where to create the database.
     errors : str, optional
-        Whether or not to raise an error if the database directory already exist.
-        Can be either `raise` or `ignore`, `ignore` tries to create a database
-        in existing directory, by default `raise`
+        Whether to raise an error if the database directory already exists.
+        Can be either `raise` or `ignore`; `ignore` tries to create a database
+        in an existing directory. Default is `raise`.
     connect : bool
         Whether or not to connect to the created database, by default True
 
@@ -79,7 +79,7 @@ def create_database(path, *, errors="raise", connect=True):
 def drop_database(path, *, warnings="warn"):
     """Deletes a database.
 
-    *Warning*: You can not delete a database containing stores. All stores must
+    *Warning*: You cannot delete a database containing stores. All stores must
     be deleted first.
 
     Parameters

--- a/featherstore/snapshot.py
+++ b/featherstore/snapshot.py
@@ -20,7 +20,7 @@ _SNAPSHOT_ARCHIVE_SUFFIX = ".tar.xz"
 
 
 def restore_table(store_name, source, *, errors="raise"):
-    """Restores a table in to the currently selected db.
+    """Restores a table into the currently connected database.
 
     Parameters
     ----------
@@ -29,9 +29,9 @@ def restore_table(store_name, source, *, errors="raise"):
     source : str
         Path to the snapshot file.
     errors : str
-        Whether or not to raise an error if a table with the same name already
-        exist. Can be either `raise` or `ignore`, `ignore` overwrites existing
-        table, by default `raise`.
+        Whether to raise an error if a table with the same name already
+        exists. Can be either `raise` or `ignore`; `ignore` overwrites the
+        existing table. Default is `raise`.
 
     Returns
     -------
@@ -66,16 +66,16 @@ def restore_table(store_name, source, *, errors="raise"):
 
 
 def restore_store(source, *, errors="raise"):
-    """Restores a store in to the currently selected db.
+    """Restores a store into the currently connected database.
 
     Parameters
     ----------
     source : str
         Path to the snapshot file.
     errors : str
-        Whether or not to raise an error if a store with the same name already
-        exist. Can be either `raise` or `ignore`, `ignore` overwrites existing
-        store, by default `raise`.
+        Whether to raise an error if a store with the same name already
+        exists. Can be either `raise` or `ignore`; `ignore` overwrites the
+        existing store. Default is `raise`.
 
     Returns
     -------

--- a/featherstore/store.py
+++ b/featherstore/store.py
@@ -20,9 +20,9 @@ def create_store(store_name, *, warnings="warn"):
     store_name : str
         The name of the store to be created
     warnings : str, optional
-        Whether or not to warn if the store already exist. Can be either
-        `warn` or `ignore`, `ignore` passes silently if the store already
-        exists, by default `warn`
+        Whether to warn if the store already exists. Can be either
+        `warn` or `ignore`; `ignore` passes silently if the store already
+        exists. Default is `warn`.
 
     Returns
     -------
@@ -76,7 +76,7 @@ def rename_store(store_name, *, to):
 def drop_store(store_name, *, warnings="warn"):
     """Deletes a store
 
-    *Warning*: You can not delete a store containing tables. All tables must
+    *Warning*: You cannot delete a store containing tables. All tables must
     be deleted first.
 
     Parameters
@@ -140,7 +140,7 @@ def store_exists(store_name):
 
 class Store:
     def __init__(self, store_name):
-        """A class for doing basic tasks with tables within a store.
+        """A class for common table operations within a store.
 
         Stores are directories for organizing data in logical groups
         within your FeatherStore database.
@@ -196,7 +196,7 @@ class Store:
     def drop(self, *, warnings="warn"):
         """Deletes the current store
 
-        *Warning*: You can not delete a store containing tables. All tables must
+        *Warning*: You cannot delete a store containing tables. All tables must
         be deleted first.
 
         Parameters
@@ -245,7 +245,7 @@ class Store:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -288,7 +288,7 @@ class Store:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -331,7 +331,7 @@ class Store:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -400,8 +400,8 @@ class Store:
             The size of each partition in bytes. A `partition_size` value of `-1`
             disables partitioning, by default 128 MB
         errors : str, optional
-            Whether or not to raise an error if the table already exist. Can be either
-            `raise` or `ignore`, `ignore` overwrites existing table, by default `raise`
+            Whether to raise an error if the table already exists. Can be either
+            `raise` or `ignore`; `ignore` overwrites the existing table. Default is `raise`
         warnings : str, optional
             Whether or not to warn if an unsorted index is about to get sorted.
             Can be either `warn` or `ignore`, by default `warn`
@@ -446,7 +446,7 @@ class Store:
         ----------
         table_name : str
             The name of the table you want to append to
-        df : Pandas DataFrame or Series, Polars DataFrame or Series, or Pyarrow Table
+        df : Pandas DataFrame or Series, Polars DataFrame or Series, or PyArrow Table
             The data to be appended
         warnings : str, optional
             Whether or not to warn if an unsorted index is about to get sorted.

--- a/featherstore/store.py
+++ b/featherstore/store.py
@@ -401,7 +401,8 @@ class Store:
             disables partitioning, by default 128 MB
         errors : str, optional
             Whether to raise an error if the table already exists. Can be either
-            `raise` or `ignore`; `ignore` overwrites the existing table. Default is `raise`
+            `raise` or `ignore`; `ignore` overwrites the existing table.
+            Default is `raise`.
         warnings : str, optional
             Whether or not to warn if an unsorted index is about to get sorted.
             Can be either `warn` or `ignore`, by default `warn`

--- a/featherstore/table.py
+++ b/featherstore/table.py
@@ -26,8 +26,8 @@ class Table:
     def __init__(self, table_name, store_name):
         """A class for saving and loading DataFrames as partitioned Feather files.
 
-        Tables supports several operations that can be done without loading in the
-        full data:
+        Tables support several operations that can be done without loading the
+        full dataset:
 
         - Partial reading of data
         - Append data
@@ -67,7 +67,7 @@ class Table:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -124,7 +124,7 @@ class Table:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -152,7 +152,7 @@ class Table:
         Parameters
         ----------
         cols : Collection, optional
-            List of column names or, filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`. If not provided, all columns are read.
         rows : Collection, optional
             List of index values or filter-predicates in the form of
@@ -203,8 +203,8 @@ class Table:
             The size of each partition in bytes. A `partition_size` value of `-1`
             disables partitioning, by default 128 MB
         errors : str, optional
-            Whether or not to raise an error if the table already exist. Can be either
-            `raise` or `ignore`, `ignore` overwrites existing table, by default `raise`
+            Whether to raise an error if the table already exists. Can be either
+            `raise` or `ignore`; `ignore` overwrites the existing table. Default is `raise`
         warnings : str, optional
             Whether or not to warn if an unsorted index is about to get sorted.
             Can be either `warn` or `ignore`, by default `warn`
@@ -529,10 +529,10 @@ class Table:
         Parameters
         ----------
         cols : Collection, optional
-            list of column names or filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`, by default `None`
         rows : Collection, optional
-            list of index values or, filter-predicates in the form of
+            List of index values or filter predicates in the form of
             `{keyword: value}`, where keyword can be either `before`, `after`,
             or `between`, by default `None`
 
@@ -575,7 +575,7 @@ class Table:
         Parameters
         ----------
         rows : Collection, optional
-            list of index values or, filter-predicates in the form of
+            List of index values or filter predicates in the form of
             `{keyword: value}`, where keyword can be either `before`, `after`,
             or `between`, by default `None`
 
@@ -616,7 +616,7 @@ class Table:
         Parameters
         ----------
         cols : Collection, optional
-            list of column names or filter-predicates in the form of
+            List of column names or filter predicates in the form of
             `{'like': pattern}`, by default `None`
 
         Raises
@@ -659,7 +659,7 @@ class Table:
     def rename_columns(self, cols, *, to=None):
         """Rename one or more columns.
 
-        `rename_columns` supports two different call-syntaxes:
+        `rename_columns` supports two different call syntaxes:
 
         - `rename_columns({'c1': 'new_c1', 'c2': 'new_c2'})`
         - `rename_columns(['c1', 'c2'], to=['new_c1', 'new_c2'])`
@@ -723,7 +723,7 @@ class Table:
     def columns(self, cols):
         """Same as `Table.reorder_columns(values)`
 
-        *Note*: You can not use this method to rename columns, use `rename_columns`
+        *Note*: You cannot use this method to rename columns; use `rename_columns`
         instead.
 
         Parameters
@@ -781,7 +781,7 @@ class Table:
     def astype(self, cols, *, to=None):
         """Change data type of one or more columns.
 
-        `astype` supports two different call-syntaxes:
+        `astype` supports two different call syntaxes:
 
         - `astype({'c1': pa.int64(), 'c2': pa.int16()})`
         - `astype(['c1', 'c2'], to=[pa.int64(), pa.int16()])`
@@ -789,9 +789,9 @@ class Table:
         Parameters
         ----------
         cols : Sequence[str] or dict
-            Either a sequence of columns to have its data types changed, or a
+            Either a sequence of columns to have their data types changed, or a
             dict mapping columns to new column data types.
-        to : Sequence[Pyarrow DataType], optional
+        to : Sequence[PyArrow DataType], optional
             New column data types, by default `None`
 
         Raises

--- a/featherstore/table.py
+++ b/featherstore/table.py
@@ -204,7 +204,8 @@ class Table:
             disables partitioning, by default 128 MB
         errors : str, optional
             Whether to raise an error if the table already exists. Can be either
-            `raise` or `ignore`; `ignore` overwrites the existing table. Default is `raise`
+            `raise` or `ignore`; `ignore` overwrites the existing table.
+            Default is `raise`.
         warnings : str, optional
             Whether or not to warn if an unsorted index is about to get sorted.
             Can be either `warn` or `ignore`, by default `warn`
@@ -368,6 +369,9 @@ class Table:
         If ``df`` column names match the stored table, rows are inserted.
         Otherwise, columns are inserted at position ``idx``.
 
+        Also raises the same exceptions as :meth:`insert_rows` and
+        :meth:`insert_columns`.
+
         Parameters
         ----------
         df : pandas DataFrame or Series, polars DataFrame, or pyarrow Table
@@ -384,7 +388,6 @@ class Table:
         ------
         TypeError
             If ``idx`` is passed when inserting rows.
-        Same exceptions as :meth:`insert_rows` and :meth:`insert_columns`.
         """
         insert.can_insert(df, self._table_data, idx)
         if insert.cols_matches_table_cols(df, self._table_data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "FeatherStore"
 dynamic = ["version"]
-description = "High performance datastore built upon Apache Arrow & Feather"
+description = "High-performance datastore built on Apache Arrow and Feather"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a writing pass over the README, Sphinx pages, and a few public API docstrings that Sphinx publishes.

It does not change runtime behavior. The edits fix spelling and grammar, tighten informal or marketing-heavy phrasing, and keep the README, overview, and quickstart in the same voice.

Notable copy fixes:
- Subject-verb agreement (`FeatherStore support` → `supports`, `Tables supports` → `Tables support`, `already exist` → `already exists`)
- Missing words and punctuation in the quickstart (`The advantage with using partitioned Feather files that you can do...`)
- Hyphenation and units (`high-performance`, `GB`/`MB`, `MB/s`)
- Informal or overstated tone in the README closer and the benchmarks page
- A mismatched update example in the quickstart (`[[0, 2], [1, 3]]` vs the shown table)
- Duplicate anonymous `here` links on the benchmarks page, and a `Table.insert` Raises field that autodoc could not parse

Checked with `doc8` (0 errors), `ruff` on the edited Python files, and `sphinx-build -W`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01eab-0daa-7d13-a5e9-f43ab4bfb821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01eab-0daa-7d13-a5e9-f43ab4bfb821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

